### PR TITLE
[EDS-519] Support automated deployments to dev

### DIFF
--- a/.github/scripts/promote.sh
+++ b/.github/scripts/promote.sh
@@ -1,0 +1,48 @@
+EXIT=
+DOCKERHUB_USERNAME="${DOCKERHUB_USERNAME}"   # Secret from env
+DOCKERHUB_PASSWORD="${DOCKERHUB_PASSWORD}"   # Secret from env
+
+while (( $# ))
+do
+  case $1 in
+    --source|-s)
+      shift
+      SOURCE=$1
+      ;;
+    --dest|-d)
+      shift
+      DEST=$1
+      ;;
+  esac
+  shift
+done
+
+conditional_exit() {
+  if test -n "${EXIT}"
+  then
+    exit $EXIT
+  fi
+}
+
+if test -z "${SOURCE}"
+then
+  echo "No --source/-s provided."
+  EXIT=1
+fi
+if test -z "${DEST}"
+then
+  echo "No --dest/-d provided."
+  EXIT=1
+fi
+
+set -e
+
+conditional_exit
+
+echo "${DOCKERHUB_PASSWORD}" | docker login -u ${DOCKERHUB_USERNAME} --password-stdin
+
+echo "Tagging image ${SOURCE} as ${DEST}."
+docker pull "${SOURCE}"
+docker tag "${SOURCE}" "${DEST}"
+docker push "${DEST}"
+echo "Push to ${DEST} successful."

--- a/.github/workflows/post-push.yml
+++ b/.github/workflows/post-push.yml
@@ -30,23 +30,28 @@ jobs:
         name: Creates a fully qualified image name with the tag
         id: image_with_tag
         env:
-          TAG_NAME: ${{ steps.commit_tag.outputs.tag_name }}
+          COMMIT_TAG_NAME: ${{ steps.commit_tag.outputs.tag_name }}
           IMAGE_NAME: ${{ steps.image_name.outputs.image_name }}
-        run: echo ::set-output name=name_with_tag::${IMAGE_NAME}:${TAG_NAME}
+        run: echo ::set-output name=name_with_commit_tag::${IMAGE_NAME}:${COMMIT_TAG_NAME}
     outputs:
       full_image_name: ${{ steps.image_name.outputs.image_name }}
       tag_name: ${{ steps.commit_tag.outputs.tag_name }}
-      image_name_with_tag: ${{ steps.image_with_tag.outputs.name_with_tag }}
+      image_name_with_commit_tag: ${{ steps.image_with_tag.outputs .name_with_commit_tag }}
   # This job is responsible for building an image and uploading it to our repository. This image can later be
   # tested, deployed, and/or have other tags applied.
   build-and-push-image:
     needs: [configure-image]
     runs-on: ubuntu-latest
+    env:
+      # TODO:
+      # In eval, we will instead use the release candidate tag name (e.g., 1.2.3-rc.1)
+      # In prod, we will use the semver tag name (e.g., 1.2.3)
+      BUILD_ID: ${{ github.sha }}
     steps:
       - uses: actions/checkout@master
-      # Pushes the public image based on the commit to dockerhub.
-      # This could then be used in subsequent jobs to tag versions in deployment repositories.
-      - id: container_push
+      - # Pushes the public image based on the commit to dockerhub.
+        # This could then be used in subsequent jobs to tag versions in deployment repositories.
+        id: container_push
         name: Build and push docker container
         uses: elgohr/Publish-Docker-Github-Action@master
         with:
@@ -56,16 +61,36 @@ jobs:
           name: ${{ needs.configure-image.outputs.full_image_name }}
           tags: ${{ needs.configure-image.outputs.tag_name }}
           dockerfile: docker/development-server.dockerfile
-          cache: false
+          buildargs: BUILD_ID
+          cache: true
 
   # This uses the image built above to run validations and tests from inside the image.
   validate-image-quality:
     needs: [configure-image, build-and-push-image]
     runs-on: ubuntu-latest
     container:
-      image: ${{ needs.configure-image.outputs.image_name_with_tag }}
+      image: ${{ needs.configure-image.outputs.image_name_with_commit_tag }}
     steps:
       - uses: actions/checkout@master
       -
         name: Run validation checks and tests
         run: /scripts/validate-development-image.sh
+
+  # If the validation steps above succeed, these deployment workflows may run.
+  promote-deployment:
+    # - configure-image exports variables used here
+    # - validate-image-quality is required to succeed before any promotions are run
+    needs: [configure-image, validate-image-quality]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Deploy to uw-directory.iamdev.s.uw.edu from the 'main' branch
+        id: deploy_main_to_dev
+        env:
+          IMAGE_NAME: ${{ needs.configure-image.outputs.full_image_name }}
+          IMAGE_SOURCE: ${{ needs.configure-image.outputs.image_name_with_commit_tag }}
+          COMMIT_TAG: ${{ needs.configure-image.outputs.tag_name }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+        if: github.ref == 'refs/heads/main'
+        run: ./.github/scripts/promote.sh -s "${IMAGE_SOURCE}" -d "${IMAGE_NAME}:deploy-dev.${COMMIT_TAG}"

--- a/docker/development-server.dockerfile
+++ b/docker/development-server.dockerfile
@@ -28,6 +28,7 @@ COPY husky_directory/ ./husky_directory
 # The next line allows the local network (e.g., your laptop) to communicate with the
 # image, so that you can simply use: localhost:8000 in your browser.
 EXPOSE 8000
+ARG BUILD_ID
 ENV FLASK_PORT=8000 \
     FLASK_ENV=development \
     PYTHONPATH=/app:$PYTHONPATH \

--- a/husky_directory/app_config.py
+++ b/husky_directory/app_config.py
@@ -2,6 +2,7 @@ import logging
 import os
 import secrets
 import string
+from datetime import datetime
 from typing import Dict, Optional, Type, TypeVar, Union
 
 import yaml
@@ -11,6 +12,7 @@ from pydantic import BaseSettings, Field, SecretStr, validator
 logger = logging.getLogger("app_config")
 
 
+@singleton
 class ApplicationConfig(BaseSettings):
     """
     Base settings for the application. These can be provided by a dotenv file, environment variables, or directly
@@ -29,9 +31,7 @@ class ApplicationConfig(BaseSettings):
         # Loaded entirely from environment variables:
         ApplicationConfig(settings_dir='/foo/settings')
     """
-
     settings_dir: str
-
     uwca_cert_name: str = Field(..., env="UWCA_CERT_NAME")
     uwca_cert_path: str = Field(..., env="UWCA_CERT_PATH")
     pws_host: str = Field(..., env="PWS_HOST")
@@ -41,6 +41,8 @@ class ApplicationConfig(BaseSettings):
     saml_acs_url: str = Field(..., env="SAML_ACS_URL")
     cookie_secret_key: Optional[str] = Field(None, env="COOKIE_SECRET_KEY")
     use_test_idp: bool = Field(False, env="USE_TEST_IDP")
+    build_id: Optional[str] = Field(None, env="BUILD_ID")
+    start_time: datetime = Field(datetime.now())
 
     @property
     def uwca_certificate_path(self):

--- a/husky_directory/app_config.py
+++ b/husky_directory/app_config.py
@@ -31,6 +31,7 @@ class ApplicationConfig(BaseSettings):
         # Loaded entirely from environment variables:
         ApplicationConfig(settings_dir='/foo/settings')
     """
+
     settings_dir: str
     uwca_cert_name: str = Field(..., env="UWCA_CERT_NAME")
     uwca_cert_path: str = Field(..., env="UWCA_CERT_PATH")

--- a/husky_directory/blueprints/app.py
+++ b/husky_directory/blueprints/app.py
@@ -1,23 +1,46 @@
 import logging
+from typing import Optional
 
 from flask import Blueprint, Request, jsonify, render_template
+from injector import inject
+from pydantic import BaseModel, Extra
+
+from husky_directory.app_config import ApplicationConfig
+from husky_directory.util import camelize
+
+
+class HealthReport(BaseModel):
+    class Config:
+        alias_generator = camelize
+        extra = Extra.ignore
+        allow_population_by_field_name = True
+
+    ready: bool
+    build_id: Optional[str]
+    start_time: str
 
 
 class AppBlueprint(Blueprint):
     """Blueprint for root urls within the application."""
 
-    def __init__(self):
+    @inject
+    def __init__(self, app_config: ApplicationConfig):
         super().__init__("uw-directory", __name__)
         self.add_url_rule("/", view_func=self.index)
         self.add_url_rule("/health", view_func=self.health)
+        self.build_id = app_config.build_id
+        self.start_time = app_config.start_time
 
     @staticmethod
     def index(request: Request, logger: logging.Logger):
         logger.info(f"Someone is here: {request}")
         return render_template("index.html")
 
-    @staticmethod
-    def health(request: Request):
-        request.get_data()
-        status = {"ready": "ready" in request.args}
-        return jsonify(status)
+    def health(self, request: Request):
+        report = HealthReport(
+            ready="ready"
+            in request.args,  # Someday maybe this will do something, now it just pretends to
+            build_id=self.build_id,
+            start_time=self.start_time.strftime("%y-%m-%d %H:%M:%S"),
+        )
+        return jsonify(report.dict())

--- a/husky_directory/models/search.py
+++ b/husky_directory/models/search.py
@@ -4,8 +4,9 @@ Models for the DirectorySearchService.
 import re
 from typing import List, Optional
 
-import inflection
 from pydantic import BaseModel, Extra, Field, validator
+
+from husky_directory.util import camelize
 
 
 class DirectoryBaseModel(BaseModel):
@@ -14,12 +15,7 @@ class DirectoryBaseModel(BaseModel):
         use_enum_values = True
         allow_population_by_field_name = True
         validate_assignment = True
-
-        @staticmethod
-        def to_camel(s: str) -> str:
-            return inflection.camelize(s, uppercase_first_letter=False)
-
-        alias_generator = to_camel
+        alias_generator = camelize
 
 
 class SearchDirectoryInput(DirectoryBaseModel):

--- a/husky_directory/util.py
+++ b/husky_directory/util.py
@@ -1,3 +1,4 @@
+import inflection
 from devtools.debug import PrettyFormat
 from injector import Module, provider, singleton
 
@@ -16,3 +17,8 @@ class UtilityInjectorModule(Module):
             print(injector.get(PrettyFormat)(obj))
         """
         return PrettyFormat(simple_cutoff=0)  # Always show list items 1 per line.
+
+
+def camelize(string: str, uppercase_first_letter=False) -> str:
+    """Fixes the default behavior to keep the first character lowerCased."""
+    return inflection.camelize(string, uppercase_first_letter=uppercase_first_letter)

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -108,7 +108,7 @@ conditional_echo "ℹ️ Commit tag is: ${COMMIT_TAG}"
 IMAGE_NAME="$DOCKER_ORG/$APP_NAME:$COMMIT_TAG"
 PERSONAL_IMAGE="$DOCKER_ORG/$APP_NAME:personal-$PERSONAL_IMAGE_SUFFIX"
 
-if ! black --check $SRC_DIR $TST_DIR
+if ! black --check $SRC_DIR $TST_DIR > /dev/null
 then
   conditional_echo "ℹ️ Blackening all code . . ."
   black $SRC_DIR $TST_DIR

--- a/scripts/run-development-server.sh
+++ b/scripts/run-development-server.sh
@@ -71,7 +71,7 @@ then
   fi
   MOUNTLOCAL="${MOUNTLOCAL} --mount type=bind,source=${UWCA_CERT_PATH},target=/app/certificates"
 else
-  echo "WARNING: No certificate is being mounted. Running the application may fail."
+  echo "WARNING: No certificate is being mounted. You can still view the UI, but the search function will fail."
 fi
 
 docker build -f docker/development-server.dockerfile -t "uw-husky-directory-local" .

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -16,7 +16,7 @@ def test_get_health(client):
 
 def test_get_ready(client):
     response = client.get("/health?ready")
-    assert response.status_code == 200
+    assert response.status_code == 200, response.data
     assert response.json["ready"] is True
 
 

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -32,6 +32,8 @@ class TestApplicationConfig:
             "saml_acs_url",
             "use_test_idp",
             "saml_entity_id",
+            "build_id",
+            "start_time",
         }
         assert set(self.app_config.dict().keys()) == expected_field_names
 


### PR DESCRIPTION
Closes EDS-519

- Adds support for a build id and start time (i.e., tag, commit, etc.) in the health report (similar to identity/healthz)
- Adds a promotion script that logs into docker, re-tags an image, then pushes the resulting image
- Adds a workflow job that will run if the validation step succeeds that executes the promotion script

NB: You can see that in the check suite that ran after [this code was pushed](https://github.com/UWIT-IAM/uw-husky-directory/pull/13/checks?check_run_id=1773701094) that the deploy step was skipped because the branch I pushed to (`EDS-519`) is not `main`. 

[Here](https://github.com/UWIT-IAM/uw-husky-directory/runs/1773467011?check_suite_focus=true) is an example of the script running and pushing a new image (although I changed a couple of values to not _actually_ deploy to dev while testing.