### PR TITLE
Make it possible to pull and run any development server image as a one-liner

### DIFF
--- a/scripts/run-development-server.sh
+++ b/scripts/run-development-server.sh
@@ -37,6 +37,10 @@ do
       shift
       RUNENV="${RUNENV} -e $1"
       ;;
+    --image|-i)
+      shift
+      IMAGE=$1
+      ;;
     --idp)
       USE_TEST_IDP=0
       ;;
@@ -74,5 +78,12 @@ else
   echo "WARNING: No certificate is being mounted. Running the application may fail."
 fi
 
-docker build -f docker/development-server.dockerfile -t "uw-husky-directory-local" .
-docker run ${RUNENV} -p 8000:8000 ${MOUNTLOCAL} -it uw-husky-directory-local
+if test -z "${IMAGE}"
+then
+  IMAGE="uw-husky-directory-local"
+  docker build -f docker/development-server.dockerfile -t "${IMAGE}" .
+else
+  docker pull "${IMAGE}"
+fi
+
+docker run ${RUNENV} -p 8000:8000 ${MOUNTLOCAL} -it "${IMAGE}"


### PR DESCRIPTION
By default, will keep its current behavior to build an image from the existing code and run that.

You can now supply the `--image/-i` flag to name any image, which will be pulled and run. Useful for testing commits associated with PRs!

e.g., `./scripts/run-development-server.sh -i uwitiam/husky-directory:commit-07428c4d65`