### PR TITLE
Fix error in bootstrap css link

### DIFF
--- a/husky_directory/templates/index.html
+++ b/husky_directory/templates/index.html
@@ -13,7 +13,8 @@
 
         <!-- Desktop -->
         <link rel="stylesheet"
-              href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.css"type="text/css"/>
+              href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.css"
+              type="text/css"/>
         <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/mini.css') }}">
         <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/body.css') }}">
 


### PR DESCRIPTION
Firefox was complaining that there were no spaces between attributes:

![Screen Shot 2021-01-28 at 2 40 42 PM](https://user-images.githubusercontent.com/1092941/106207567-d0ad8500-6176-11eb-9686-8b908e784bde.png)

![Screen Shot 2021-01-28 at 2 40 33 PM](https://user-images.githubusercontent.com/1092941/106207575-d30fdf00-6176-11eb-8c2c-a0e1454783cb.png)
