### PR TITLE
Modify summary results to show only the 'phone' field.

### DIFF
--- a/husky_directory/templates/summary_results.html
+++ b/husky_directory/templates/summary_results.html
@@ -27,7 +27,9 @@
                                                 {% for data in scenario['people'] %}
                                                     <tr>
                                                         <td valign="top">{{ data['name'] }}&nbsp;</td>
-                                                        <td valign="top" nowrap="nowrap">{{ data['phone'] }}&nbsp;</td>
+                                                        <td valign="top" nowrap="nowrap">
+                                                            {{ data['phoneContacts']['phone']|first}}
+                                                        </td>
                                                         <td valign="top">{{ data['email'] }}&nbsp;</td>
                                                         <td valign="top">theNetIdWouldBeHere&nbsp;</td>
                                                         <td>


### PR DESCRIPTION
We have new backend results bringing in multiple phone numbers. For the **summary** results page, this change will show just the `phone` per the old/current directory.
Closes (EDS-550 and EDS-527)