### PR TITLE
[EDS-517] Supports box number queries

### DIFF
--- a/husky_directory/app.py
+++ b/husky_directory/app.py
@@ -65,6 +65,7 @@ class AppInjectorModule(Module):
     @staticmethod
     def register_jinja_filters(app: Flask):
         """You can define jinja filters here in order to make them available in our jinja templates."""
+
         @app.template_filter()
         def titleize(text):
             """

--- a/husky_directory/app.py
+++ b/husky_directory/app.py
@@ -5,6 +5,7 @@ from typing import List, NoReturn, Optional, Type
 from flask import Flask, session
 from flask_injector import FlaskInjector, request
 from injector import Injector, Module, provider, singleton
+from inflection import titleize as titleize_
 from pydantic import ValidationError
 from uw_saml2 import mock, python3_saml
 from werkzeug.exceptions import BadRequest, HTTPException, InternalServerError
@@ -61,6 +62,17 @@ class AppInjectorModule(Module):
         gunicorn_error_logger = logging.getLogger("gunicorn.error")
         return gunicorn_error_logger
 
+    @staticmethod
+    def register_jinja_filters(app: Flask):
+        """You can define jinja filters here in order to make them available in our jinja templates."""
+        @app.template_filter()
+        def titleize(text):
+            """
+            Turns snake_case and camelCase into "Snake Case" and "Camel Case," respectively.
+            Use: {{ some_string|titleize }}
+            """
+            return titleize_(text)
+
     @provider
     @singleton
     def provide_app(
@@ -96,6 +108,7 @@ class AppInjectorModule(Module):
         # our dependencies appropriate for each request.
         FlaskInjector(app=app, injector=injector)
         attach_app_error_handlers(app)
+        self.register_jinja_filters(app)
         return app
 
 

--- a/husky_directory/blueprints/search.py
+++ b/husky_directory/blueprints/search.py
@@ -38,5 +38,13 @@ class SearchBlueprint(Blueprint):
             return render_template("index.html", error=reportable_error), 401
         except Exception as e:
             logger.exception(str(e))
-            return render_template("index.html", error={'msg': "Something unexpected happened. Please try again or "
-                                                               "email help@uw.edu describing your problem."}), 500
+            return (
+                render_template(
+                    "index.html",
+                    error={
+                        "msg": "Something unexpected happened. Please try again or "
+                        "email help@uw.edu describing your problem."
+                    },
+                ),
+                500,
+            )

--- a/husky_directory/blueprints/search.py
+++ b/husky_directory/blueprints/search.py
@@ -2,6 +2,7 @@ from logging import Logger
 
 from flask import Blueprint, Request, jsonify, render_template
 from injector import inject, singleton
+from pydantic import ValidationError
 
 from husky_directory.models.search import SearchDirectoryInput
 from husky_directory.services.search import DirectorySearchService
@@ -24,7 +25,18 @@ class SearchBlueprint(Blueprint):
             request_output.dict(by_alias=True, exclude_none=True, exclude_unset=True)
         )
 
-    def render(self, request: Request, service: DirectorySearchService):
-        return render_template(
-            "index.html", search_result=self.search(request, service).get_json()
-        )
+    def render(self, request: Request, service: DirectorySearchService, logger: Logger):
+        try:
+            return render_template(
+                "index.html", search_result=self.search(request, service).get_json()
+            )
+        except ValidationError as e:
+            # By default, the app just returns a BadRequest error, which is fine for
+            # an API context, but not so fine when we want to display something
+            # meaningful. Since we want to render the view, we pass the error context.
+            reportable_error = e.errors()[0]
+            return render_template("index.html", error=reportable_error), 401
+        except Exception as e:
+            logger.exception(str(e))
+            return render_template("index.html", error={'msg': "Something unexpected happened. Please try again or "
+                                                               "email help@uw.edu describing your problem."}), 500

--- a/husky_directory/models/search.py
+++ b/husky_directory/models/search.py
@@ -4,7 +4,7 @@ Models for the DirectorySearchService.
 import re
 from typing import List, Optional
 
-from pydantic import BaseModel, Extra, Field
+from pydantic import BaseModel, Extra, Field, PydanticValueError, validator
 
 from husky_directory.util import camelize
 
@@ -18,13 +18,23 @@ class DirectoryBaseModel(BaseModel):
         alias_generator = camelize
 
 
+class BoxNumberValueError(PydanticValueError):
+    """
+    We raise the custom BoxNumberValueError to closely match the legacy directory product,
+    however we add a little extra messaging in that error to be nicer to user.
+    """
+
+    code = "invalid_mail_box"
+    msg_template = "invalid mailbox number; must be value of at most 6 digits"
+
+
 class SearchDirectoryInput(DirectoryBaseModel):
     name: Optional[str] = Field(None, max_length=128)
     department: Optional[str] = Field(None, max_length=128)
     email: Optional[str] = Field(
         None, max_length=256
     )  # https://tools.ietf.org/html/rfc5321#section-4.5.3
-    box_number: Optional[str] = Field(None, regex="^[0-9]+$", max_length=32)
+    box_number: Optional[str]
     phone: Optional[str]
     netid: Optional[str] = Field(None)
 
@@ -33,6 +43,17 @@ class SearchDirectoryInput(DirectoryBaseModel):
         if self.phone:
             return re.sub("[^0-9]", "", self.phone)
         return self.phone
+
+    @validator("box_number")
+    def validate_box_number(cls, box_number: Optional[str]) -> Optional[str]:
+        if not box_number:
+            return box_number
+
+        # We don't do a lot of input validation in the legacy directory product, but
+        # this is one of them! This regex guarantees the result is a string of at most 6 digits.
+        if not re.match("^[0-9]{1,6}", box_number):
+            raise BoxNumberValueError()
+        return box_number
 
 
 class PhoneContactMethods(DirectoryBaseModel):

--- a/husky_directory/services/query_generator.py
+++ b/husky_directory/services/query_generator.py
@@ -274,6 +274,20 @@ class SearchQueryGenerator:
                 phone_number=no_country_code
             )
 
+    @staticmethod
+    def generate_mail_box_queries(box_number: str) -> Tuple[str, ListPersonsInput]:
+        # PWS only ever returns "begins with" results for mailstop.
+        yield f'Mailstop begins with "{box_number}"', ListPersonsInput(
+            mail_stop=box_number
+        )
+        # All (most?) UW mail stops start with '35,' and so it is considered shorthand to omit
+        # them at times. To be sure we account for shorthand input, we will also always try
+        # adding '35' to every query.
+        alt_number = f"35{box_number}"
+        yield f'Mailstop begins with "35{alt_number}"', ListPersonsInput(
+            mail_stop=alt_number
+        )
+
     def generate(
         self, request_input: SearchDirectoryInput
     ) -> Iterable[Tuple[str, ListPersonsInput]]:
@@ -283,5 +297,10 @@ class SearchQueryGenerator:
         elif request_input.sanitized_phone:
             for description, query in self.generate_phone_queries(
                 request_input.sanitized_phone
+            ):
+                yield description, query
+        elif request_input.box_number:
+            for description, query in self.generate_mail_box_queries(
+                request_input.box_number
             ):
                 yield description, query

--- a/husky_directory/templates/error_display.html
+++ b/husky_directory/templates/error_display.html
@@ -1,0 +1,15 @@
+<div class="contenttable">
+    <div class="contentspacer"></div>
+    <div class="contentcell">
+        {% if search_result is defined %}
+            <p>No matches for
+                <b>
+                    {{ search_result['request'].keys()|first|titleize }}
+                    is "{{ search_result['request'].values()|first }}"
+                </b>.
+            </p>
+        {% elif error is defined %}
+            <p>Encountered error: <b>"{{ error["msg"] }}"</b></p>
+        {% endif %}
+    </div>
+</div>

--- a/husky_directory/templates/index.html
+++ b/husky_directory/templates/index.html
@@ -94,25 +94,11 @@
                 {% include "search.html" %}
 
                 <hr/>
-                {% if search_result is defined %}
-                    {% if search_result["numResults"] > 0 %}
-                        {% include "results.html"%}
-                    {% else %}
-                        <div class="contenttable">
-                            <div class="contentspacer"></div>
-                            <div class="contentcell">
-                                <p>No matches for
-                                    <b>
-                                    {{ search_result['request'].keys()
-                                    |first|capitalize }}
-                                    is "{{ search_result['request'].values()|first }}"
-                                    </b>.
-                                </p>
-                            </div>
-                        </div>
-                    {% endif %}
+                {% if search_result is defined and search_result["numResults"] > 0 %}
+                    {% include "results.html" %}
+                {% else %}
+                    {% include 'error_display.html' %}
                 {% endif %}
-
                 {% include "links.html" %}
             </div>
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -29,6 +29,21 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)"
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.9.3"
+description = "Screen-scraping library"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+soupsieve = {version = ">1.2", markers = "python_version >= \"3.0\""}
+
+[package.extras]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
+
+[[package]]
 name = "black"
 version = "20.8b1"
 description = "The uncompromising code formatter."
@@ -511,6 +526,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "soupsieve"
+version = "2.2"
+description = "A modern CSS selector implementation for Beautiful Soup."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -589,7 +612,7 @@ lxml = ">=3.8"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.9"
-content-hash = "1b239de68f27651fae0bb41e5badccea9033eecdb6b3844237e4990c92135a5e"
+content-hash = "d1ece3f1969f20a0b5288f35885a7ac5e1b1cc7e7061fd3ae2cfe6b346bbbf64"
 
 [metadata.files]
 appdirs = [
@@ -603,6 +626,11 @@ atomicwrites = [
 attrs = [
     {file = "attrs-20.3.0-py2.py3-none-any.whl", hash = "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6"},
     {file = "attrs-20.3.0.tar.gz", hash = "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"},
+]
+beautifulsoup4 = [
+    {file = "beautifulsoup4-4.9.3-py2-none-any.whl", hash = "sha256:4c98143716ef1cb40bf7f39a8e3eec8f8b009509e74904ba3a7b315431577e35"},
+    {file = "beautifulsoup4-4.9.3-py3-none-any.whl", hash = "sha256:fff47e031e34ec82bf17e00da8f592fe7de69aeea38be00523c04623c04fb666"},
+    {file = "beautifulsoup4-4.9.3.tar.gz", hash = "sha256:84729e322ad1d5b4d25f805bfa05b902dd96450f43842c4e99067d5e1369eb25"},
 ]
 black = [
     {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
@@ -956,6 +984,10 @@ requests = [
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
     {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
+]
+soupsieve = [
+    {file = "soupsieve-2.2-py3-none-any.whl", hash = "sha256:d3a5ea5b350423f47d07639f74475afedad48cf41c0ad7a82ca13a3928af34f6"},
+    {file = "soupsieve-2.2.tar.gz", hash = "sha256:407fa1e8eb3458d1b5614df51d9651a1180ea5fedf07feb46e45d7e25e6d6cdd"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ pytest-flask = "^1.1.0"
 pytest-cov = "^2.10.1"
 flake8 = "^3.8.4"
 coverage = "^5.3.1"
+beautifulsoup4 = "^4.9.3"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/blueprints/test_search_blueprint.py
+++ b/tests/blueprints/test_search_blueprint.py
@@ -1,0 +1,78 @@
+import re
+from unittest import mock
+
+import pytest
+from bs4 import BeautifulSoup
+
+from husky_directory.models.pws import ListPersonsInput, ListPersonsOutput
+from husky_directory.services.pws import PersonWebServiceClient
+
+
+class TestSearchBlueprint:
+    @pytest.fixture(autouse=True)
+    def initialize(self, client, mock_person_data, injector):
+        self.pws_client = injector.get(PersonWebServiceClient)
+        self.flask_client = client
+        self.mock_list_persons = mock.patch.object(
+            self.pws_client, "list_persons"
+        ).start()
+        self.mock_get_next = mock.patch.object(self.pws_client, "get_next").start()
+        self.mock_list_persons.return_value = ListPersonsOutput.parse_obj(
+            mock_person_data
+        )
+        del mock_person_data["Next"]
+        self.mock_get_next.return_value = ListPersonsOutput.parse_obj(mock_person_data)
+
+    def test_search_success(self):
+        response = self.flask_client.get("/search/?name=foo")
+        assert response.status_code == 200
+        assert response.json["request"] == {"name": "foo"}
+        assert response.json["numResults"] > 0
+
+    def test_render_success(self):
+        response = self.flask_client.get("/search/render?name=foo")
+        assert response.status_code == 200
+        html = BeautifulSoup(response.data, "html.parser")
+        assert html.find("table", summary="results")
+
+    def test_render_no_results(self):
+        self.mock_list_persons.return_value = ListPersonsOutput(
+            persons=[],
+            page_start=0,
+            total_count=0,
+            page_size=0,
+            current=ListPersonsInput(),
+        )
+        response = self.flask_client.get("/search/render?name=foo")
+        html = BeautifulSoup(response.data, "html.parser")
+        assert not html.find("table", summary="results")
+        assert html.find(string=re.compile("No matches for"))
+        for e in html.find_all("b"):
+            # Newlines in the rendered output make it impossible for BeautifulSoup to find
+            # the text exactly, which is annoying, so we can just verify that all the pieces are
+            # together in the same <b> tag.
+            text = e.string.strip()
+            if "Name" in text and 'is "foo"' in text:
+                return
+        raise AssertionError("Not able to find correct results message in output")
+
+    def test_render_invalid_box_number(self):
+        response = self.flask_client.get("/search/render?boxNumber=abcdef")
+        html = BeautifulSoup(response.data, "html.parser")
+        assert not html.find("table", summary="results")
+        assert html.find(string=re.compile("Encountered error"))
+        assert response.status_code == 401
+        for e in html.find_all("b"):
+            if "invalid mailbox number" in e.text.strip():
+                return
+        raise AssertionError("Not able to find correct error message in output")
+
+    def test_render_unexpected_error(self):
+        self.mock_list_persons.side_effect = RuntimeError
+        response = self.flask_client.get("/search/render?boxNumber=123456")
+        html = BeautifulSoup(response.data, "html.parser")
+        assert response.status_code == 500
+        for e in html.find_all("b"):
+            if "Something unexpected happened" in e.text.strip():
+                return
+        raise AssertionError("Not able to find correct error message in output")

--- a/tests/services/test_query_generator.py
+++ b/tests/services/test_query_generator.py
@@ -176,3 +176,10 @@ class TestSearchQueryGenerator:
 
         queries = list(self.query_generator.generate(request_input))
         assert not queries
+
+    def test_box_number_input(self):
+        request_input = SearchDirectoryInput(box_number="123456")
+        queries = list(self.query_generator.generate(request_input))
+        assert len(queries) == 2
+        assert queries[0][1].mail_stop == "123456"
+        assert queries[1][1].mail_stop == "35123456"

--- a/tests/services/test_search.py
+++ b/tests/services/test_search.py
@@ -167,3 +167,8 @@ class TestDirectorySearchService:
         output = self.client.search_directory(request_input)
         assert request_input.sanitized_phone == ""
         assert output.request.phone == "abcdef"
+
+    def test_box_number_search(self):
+        request_input = SearchDirectoryInput(box_number="1234")
+        output = self.client.search_directory(request_input)
+        assert output.request.box_number == "1234"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,9 +1,3 @@
-from unittest import mock
-
-from husky_directory.models.pws import ListPersonsOutput
-from husky_directory.services.pws import PersonWebServiceClient
-
-
 def test_get_index(client):
     assert client.get("/").status_code == 200
 
@@ -18,19 +12,6 @@ def test_get_ready(client):
     response = client.get("/health?ready")
     assert response.status_code == 200, response.data
     assert response.json["ready"] is True
-
-
-def test_get_search(client, injector, mock_person_data):
-    pws = injector.get(PersonWebServiceClient)
-    mock_list_persons = mock.patch.object(pws, "list_persons").start()
-    mock_get_next = mock.patch.object(pws, "get_next").start()
-    mock_list_persons.return_value = ListPersonsOutput.parse_obj(mock_person_data)
-    del mock_person_data["Next"]
-    mock_get_next.return_value = ListPersonsOutput.parse_obj(mock_person_data)
-    response = client.get("/search/?name=foo")
-    assert response.status_code == 200, response.data
-    assert response.json["request"] == {"name": "foo"}
-    assert list(response.json["scenarios"][0]["people"])
 
 
 def test_get_login(client, injector):


### PR DESCRIPTION
Closes EDS-517

- Users can now search by box number
- Adds input validation for box number
- Adds error handling for `/search/render`
- Adds tests for rendered HTML output to cover empty results, bad box number input, and generic 500 error handling
- Slight refactor adds `error_display.html` template to handle both empty results and errors from the server, since the formatting is the same.

You can test this image with: `./scripts/run-development-server.sh -i uwitiam/husky-directory:commit-2dd4779d82` (you may also need to include the `-c` argument if you do not have your `UWCA_CERTIFICATE_PATH` environment variable set up.)