### PR TITLE
[EDS-556] Supports SAML sign-on to unlock other search options

### DIFF
--- a/husky_directory/blueprints/app.py
+++ b/husky_directory/blueprints/app.py
@@ -1,9 +1,9 @@
-import logging
 from typing import Optional
 
 from flask import Blueprint, Request, jsonify, render_template
 from injector import inject
 from pydantic import BaseModel, Extra
+from werkzeug.local import LocalProxy
 
 from husky_directory.app_config import ApplicationConfig
 from husky_directory.util import camelize
@@ -30,11 +30,11 @@ class AppBlueprint(Blueprint):
         self.add_url_rule("/health", view_func=self.health)
         self.build_id = app_config.build_id
         self.start_time = app_config.start_time
+        self._app_config = app_config
 
     @staticmethod
-    def index(request: Request, logger: logging.Logger):
-        logger.info(f"Someone is here: {request}")
-        return render_template("index.html")
+    def index(request: Request, session: LocalProxy):
+        return render_template("index.html", uwnetid=session.get("uwnetid"))
 
     def health(self, request: Request):
         report = HealthReport(

--- a/husky_directory/models/enum.py
+++ b/husky_directory/models/enum.py
@@ -13,3 +13,9 @@ class AffiliationState(Enum):
     current = "current"
     prior = "prior"
     exists = "current,prior"
+
+
+class PopulationType(Enum):
+    students = "students"
+    employees = "employees"
+    all = "all"

--- a/husky_directory/models/search.py
+++ b/husky_directory/models/search.py
@@ -6,6 +6,7 @@ from typing import List, Optional
 
 from pydantic import BaseModel, Extra, Field, PydanticValueError, validator
 
+from husky_directory.models.enum import PopulationType
 from husky_directory.util import camelize
 
 
@@ -37,6 +38,7 @@ class SearchDirectoryInput(DirectoryBaseModel):
     )  # https://tools.ietf.org/html/rfc5321#section-4.5.3
     box_number: Optional[str]
     phone: Optional[str]
+    population: PopulationType = PopulationType.employees
 
     @property
     def sanitized_phone(self) -> Optional[str]:

--- a/husky_directory/templates/index.html
+++ b/husky_directory/templates/index.html
@@ -51,25 +51,6 @@
 <!--              ga('send', 'pageview');-->
 <!--        </script>-->
 
-<!--        This script was carried over from the outgoing directory, although the id searchInput doesn't exist. -->
-<!--        There still may be a need for this as we continue to create the cloud directory -->
-<!--        <script type="text/javascript">-->
-<!--        // clear out the global search input text field-->
-<!--        $(document).ready(function() {-->
-<!--            $('#searchInput').focus(function() {-->
-<!--                var $this = $(this)-->
-<!--                if ($this.val() == $this.prop('defaultValue'))-->
-<!--                    $this.val('')-->
-
-<!--            }).blur(function() {-->
-<!--                var $this = $(this)-->
-<!--                if ($this.val() == '')-->
-<!--                    $this.val($this.prop('defaultValue'))-->
-<!--            });-->
-
-<!--        })-->
-<!--        </script>-->
-
     <!--[if lt IE 9]>
         <script src="https://www.washington.edu/wp-content/themes/uw-2014/assets/ie/js/html5shiv.js"
                 type="text/javascript"></script>

--- a/husky_directory/templates/search.html
+++ b/husky_directory/templates/search.html
@@ -22,12 +22,38 @@
                                {% include "search_options.html" %}
                             </select>
                         </div>
-<!--                        <div class="col-md-3">-->
-<!--                            <h3>Search options</h3>-->
-<!--                            <label for="whichstaff"><input type="radio" name="whichdir" value="staff"
-                                checked="checked" id="whichstaff" />Faculty/Staff Only</label>-->
-<!--                            <a href='secure'>Search students</a>-->
-<!--                        </div>-->
+                        <div id="search-population" class="col-md-3">
+                            <h3>Search options</h3>
+                            <label for="employee-population-option">
+                                <input type="radio"
+                                       id="employee-population-option"
+                                       name="population"
+                                       value="employees"
+                                       checked>
+                                Faculty/Staff Only
+                            </label>
+                            {% if uwnetid is not blank %}
+                                <label for="student-population-option">
+                                    <input type="radio"
+                                           id="student-population-option"
+                                           name="population"
+                                           value="students">
+                                    Students Only
+                                </label>
+                                <label for="all-populations-option">
+                                    <input type="radio"
+                                           id="all-populations-option"
+                                           name="population"
+                                           value="all">
+                                    Faculty/Staff and Students
+                                </label>
+                            {% else %}
+                                <a id="sign-in"
+                                   href="/saml/login">
+                                    Sign in for student search
+                                </a>
+                            {%  endif %}
+                        </div>
                         <div class="col-md-2">
                              <h3>Kind of listing</h3>
                              <label for="lengthfull"><input type="radio"  name="length" value="full"

--- a/scripts/validate-development-image.sh
+++ b/scripts/validate-development-image.sh
@@ -22,7 +22,7 @@ then
   FAIL=1
 fi
 
-CMD="pytest $TST_DIR --cov ${SRC_DIR}/husky_directory --cov-report term-missing --cov-report html --cov-fail-under 96"
+CMD="pytest $TST_DIR --cov ${SRC_DIR}/husky_directory --cov-report term-missing --cov-report html --cov-fail-under 97"
 
 echo $CMD
 if ! $CMD

--- a/tests/blueprints/test_saml_blueprint.py
+++ b/tests/blueprints/test_saml_blueprint.py
@@ -1,0 +1,66 @@
+from unittest import mock
+
+import pytest
+from bs4 import BeautifulSoup
+from flask import Response
+from flask.testing import FlaskClient
+from uw_saml2.idp.uw import UwIdp
+from werkzeug.local import LocalProxy
+
+
+class TestSAMLBlueprint:
+    @pytest.fixture(autouse=True)
+    def initialize(self, injector, client: FlaskClient):
+        self.mock_session = {}
+        self.flask_client = client
+
+        # Mock out the LocalProxy so that we can test its state
+        # before and after SAML calls.
+        orig_get = injector.get
+
+        def _injector_get(cls):
+            if cls is LocalProxy:
+                return self.mock_session
+            return orig_get(cls)
+
+        with mock.patch.object(injector, "get") as mock_injector_get:
+            mock_injector_get.side_effect = _injector_get
+            yield
+
+    def test_login(self):
+        """Logs in to the mock IdP just to validate the flow."""
+        assert not self.mock_session
+        response: Response = self.flask_client.get("/")
+        html = BeautifulSoup(response.data, "html.parser")
+        assert html.find("a", dict(id="sign-in"))
+        population_options = html.find_all("input", dict(name="population"))
+        assert len(population_options) == 1
+        response: Response = self.flask_client.get("/saml/login", follow_redirects=True)
+        html = BeautifulSoup(response.data, "html.parser")
+        assert response.status_code == 200
+        assert "uwnetid" in self.mock_session
+        assert not html.find("a", dict(id="sign-in"))
+        population_options = html.find_all("input", dict(name="population"))
+        assert len(population_options) == 3
+
+    def test_logout(self):
+        """Logs out after logging in to validate the flow."""
+        self.test_login()
+        response = self.flask_client.get("/saml/logout", follow_redirects=True)
+        html = BeautifulSoup(response.data)
+        assert html.find("a", dict(id="sign-in"))
+        assert not self.mock_session
+
+    def test_process_saml_request(self):
+        """Since the mock flow doesn't use this method, we must verify it does what it's supposed to explicitly"""
+        response = self.flask_client.post(
+            "/saml/login",
+            data={
+                "idp": UwIdp.entity_id,
+                "remote_user": "cooluser@washington.edu",
+            },
+            follow_redirects=True,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        assert response.status_code == 200
+        assert self.mock_session.get("uwnetid") == "cooluser"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from flask import Flask
 from injector import Injector
 
 from husky_directory.app import create_app, create_app_injector
+from husky_directory.app_config import ApplicationConfig
 from husky_directory.models.pws import (
     EmployeeDirectoryListing,
     EmployeePersonAffiliation,
@@ -33,8 +34,18 @@ def injector() -> Injector:
     return create_app_injector()
 
 
+@pytest.fixture
+def app_config(injector) -> ApplicationConfig:
+    config = injector.get(ApplicationConfig)
+    config.use_test_idp = True
+    return config
+
+
 @pytest.fixture(autouse=True)
-def app(injector) -> Flask:
+def app(
+    injector,
+    app_config,  # ensures app_config fixture loads before the Flask app.
+) -> Flask:
     return create_app(injector)
 
 


### PR DESCRIPTION
Note: Does **NOT** enable student search yet. The radio buttons won't currently have any effect on the search results.

- When a user visits the page, they are now shown the sign in link in order to see other search options.
- After signing in, they can select other search options
- Fixes the mock idp integration so that it works locally and is testable.
- Adds tests!

You can test these changes with:

```
./scripts/run-development-server.sh -i uwitiam/husky-directory:commit-1ebcfc9854
```
