### PR TITLE
Fix the un-mocked SAML flow

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,9 @@
+# Logging
+
+## Configuration 
+
+I'll let you know when I figure it out. See EDS-560.
+
+## Live logs
+
+- [Dev](https://uwiam.page.link/directory-errors)

--- a/docs/manual-deployments.md
+++ b/docs/manual-deployments.md
@@ -1,0 +1,19 @@
+# Manual deployments to dev
+
+If you need to deploy to dev manually, instead of going through a pull request first 
+(which may be the case if you need to check an otherwise mocked integration), you 
+can do this easily with the following commands:
+
+```
+IMAGE=uwitiam/husky-directory:deploy-dev.commit-${USER}-$(date +%Y-%m-%dT%h-%m)
+docker build -f docker/development-server.dockerfile -t ${IMAGE}
+docker push ${IMAGE}
+```
+
+**This requires dockerhub credentials** for now. I (Tom) can give some to you if you 
+need them. Soon we'll migrate this to gcr.io so that we won't have to deal with a 
+separate third-party product. (I am currently working on this migration, it won't be 
+long.)
+
+You should only have to do a manual deployment if what you are changing is not 
+testable on your local machine, e.g., something with a real IdP. (See also EDS-560.)


### PR DESCRIPTION
- Fixes the POST route calling the wrong function
- Fixes an invalid relay state being returned (or rather, not being returned at all)
- Adds some resiliency to relay state redirection.
- Adds some docs for how to deploy manually, and find logs

This change has already been deployed manually and is available to preview at https://uw-directory.iamdev.s.uw.edu.

Again, this won't actually return students i the search, but you should be able to get through the sign-in process.