### PR TITLE
Adds session support 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ node_modules
 __pycache__/
 *.py[cod]
 *$py.class
+nocommit.*  # Store arbitrary files in your local repo without committing them
+flask_session/  # Filesystem cache auto-created when running via pycharm
 
 # C extensions
 *.so

--- a/docker/development-server.dockerfile
+++ b/docker/development-server.dockerfile
@@ -1,5 +1,6 @@
 ARG BASE_VERSION=latest
 FROM gcr.io/uwit-mci-iam/husky-directory-base:${BASE_VERSION} as poetry-base
+ARG ENV_FILE=husky_directory/settings/base.dotenv
 WORKDIR /scripts
 # TODO: Move test stuff into its own layer
 COPY scripts/validate-development-image.sh ./
@@ -17,7 +18,8 @@ ENV FLASK_PORT=8000 \
     PYTHONPATH=/app:$PYTHONPATH \
     GUNICORN_LOG_LEVEL=DEBUG \
     BUILD_ID=${BUILD_ID} \
-    PATH="$POETRY_HOME/bin:$PATH"
+    PATH="$POETRY_HOME/bin:$PATH" \
+    DOTENV_FILE="$ENV_FILE"
 
 # 0.0.0.0 binding is necessary for the EXPOSE above to have any effect.
 CMD poetry run gunicorn -b 0.0.0.0:${FLASK_PORT} \

--- a/husky_directory/app.py
+++ b/husky_directory/app.py
@@ -55,7 +55,7 @@ def create_app_injector() -> Injector:
 
 
 class AppInjectorModule(Module):
-    search_attributes = list(SearchDirectoryInput.__fields__.keys())
+    search_attributes = SearchDirectoryInput.search_methods()
 
     @provider
     @request

--- a/husky_directory/app.py
+++ b/husky_directory/app.py
@@ -1,10 +1,11 @@
 import logging
 from logging.config import dictConfig
-from typing import List, NoReturn, Optional, Type
+from typing import List, NoReturn, Optional, Type, cast
 
-from flask import Flask, session
+from flask import Flask, session as flask_session
 from flask_injector import FlaskInjector, request
 import inflection
+from flask_session import Session
 from injector import Injector, Module, provider, singleton
 from jinja2.tests import test_undefined
 from pydantic import ValidationError
@@ -60,7 +61,9 @@ class AppInjectorModule(Module):
     @provider
     @request
     def provide_request_session(self) -> LocalProxy:
-        return session  # Ignore IDE errors here. I hunted this down and determined the IDE is just confused.
+        return cast(
+            LocalProxy, flask_session
+        )  # Cast this so that IDEs knows what's up; does not affect runtime
 
     @provider
     @singleton
@@ -117,12 +120,12 @@ class AppInjectorModule(Module):
 
         # We've done our pre-work; now we can create the instance itself.
         app = Flask("husky_directory")
-        app.secret_key = app_settings.cookie_secret_key
+        app.config.update(app_settings.app_configuration)
         app.url_map.strict_slashes = (
             False  # Allows both '/search' and '/search/' to work
         )
 
-        if app_settings.use_test_idp:
+        if app_settings.auth_settings.use_test_idp:
             python3_saml.MOCK = True
             mock.MOCK_LOGIN_URL = "/mock-saml/login"
             app.register_blueprint(mock_saml_blueprint)
@@ -138,6 +141,7 @@ class AppInjectorModule(Module):
         # Bind an injector to the app itself to manage the scopes of
         # our dependencies appropriate for each request.
         FlaskInjector(app=app, injector=injector)
+        Session(app)
         attach_app_error_handlers(app)
         self.register_jinja_extensions(app)
         return app

--- a/husky_directory/app_config.py
+++ b/husky_directory/app_config.py
@@ -3,7 +3,8 @@ import os
 import secrets
 import string
 from datetime import datetime
-from typing import Dict, Optional, Type, TypeVar, Union
+from enum import Enum
+from typing import Any, Dict, Optional, Type, TypeVar, Union, cast
 
 import yaml
 from injector import Module, inject, provider, singleton
@@ -12,8 +13,153 @@ from pydantic import BaseSettings, Field, SecretStr, validator
 logger = logging.getLogger("app_config")
 
 
+class SessionType(Enum):
+    """Session interface types. See flask-session documentation for full list of possibilities."""
+
+    redis = "redis"
+    filesystem = "filesystem"
+
+
+class FlaskConfigurationSettings(BaseSettings):
+    """
+    A base class to make it easier to translate environment variables to flask configuration
+    settings.
+
+    To do so, simply include `flask_config_key=FOO` in a Field definition for any model that inherits from this base
+    class.
+
+    Example:
+        class MySettings(FlaskConfigurationSettings):
+            my_string: str = Field(..., env='MY_STRING_ENV_VAR', flask_config_key='SECRET_KEY')
+
+    Now setting the `MY_STRING_ENV_VAR` variable will, when the application starts, ensure that `SECRET_KEY` is set
+    on the flask application.
+    """
+
+    class Config:
+        # Optionally, you can provide variables via a dotenv file instead of relying on all variables to be set.
+        # You can supply the DOTENV_FILE environment variable to set the location of which dotenv file to load.
+        env_file = os.environ.get("DOTENV_FILE", ".env")
+
+    @property
+    def flask_config_values(self) -> Dict[str, Any]:
+        """By default, returns an empty dict. Override this if you need to provide variables to
+        flask that aren't an easy 1:1 translation using `flask_config_key` as described above. Anything returned
+        here can be overridden by the environment itself. This dict becomes the "default" return for app_configuration.
+        """
+        return {}
+
+    @property
+    def app_configuration(self) -> Dict[str, Any]:
+        """
+        This property captures a flat key-value store of all application settings declared by this model
+        or any submodels that inherit from FlaskConfigurationSettings.
+
+        Example:
+
+            class FooSettings(FlaskConfigurationSettings):
+                bar: str = Field(42, flask_config_key='FOO_BAR')
+
+            class ModuleSettings(FlaskConfigurationSettings:
+               foo_settings: FooSettings
+               baz: int = Field(..., flask_config_key='MODULE_BAZ')
+
+            mod_settings = ModuleSettings(baz=24)
+            print(mod_settings.app_configuration)
+                { "FOO_BAR": 42, "MODULE_BAZ": 24 }
+        """
+        # If the instance has set any overrides that aren't natively included by
+        # the 'flask_config_key' attribute, we'll ensure they are included too.
+        results = self.flask_config_values
+
+        for field in self.dict().keys():
+            value = getattr(self, field)
+            if isinstance(value, FlaskConfigurationSettings):
+                results.update(value.app_configuration)
+                continue
+            field_config = self.__fields__[field].field_info.extra
+            flask_key = field_config.get("flask_config_key")
+
+            if (
+                flask_key == "_env"
+            ):  # If someone wants to use the same name as the environment variable
+                flask_key = field_config["env"]
+
+            if flask_key:
+                if isinstance(value, Enum):
+                    value = value.value
+                results[flask_key] = value
+        return results
+
+
+class RedisSettings(FlaskConfigurationSettings):
+    """
+    Settings for connecting to redis.
+    The redis namespace is also our username.
+    """
+
+    host: str = Field(None, env="REDIS_HOST")
+    port: str = Field("6379", env="REDIS_PORT")
+    namespace: str = Field(None, env="REDIS_NAMESPACE")
+    password: SecretStr = Field(None, env="REDIS_PASSWORD")
+
+    @property
+    def flask_config_values(self) -> Dict[str, Any]:
+        # These are derived from more than one environment variable,
+        # so are not configured via the flask_config_key.
+        # see FlaskConfigurationSettings.flask_config_values
+        return {
+            "SESSION_KEY_PREFIX": f"{self.namespace}:session:",
+            "SESSION_REDIS": f"{self.host}:{self.port}",
+        }
+
+
+class SessionSettings(FlaskConfigurationSettings):
+    cookie_name: str = Field(
+        "edu.uw.identity.session", env="SESSION_COOKIE_NAME", flask_config_key="_env"
+    )
+    secret_key: SecretStr = Field(None, env="SECRET_KEY", flask_config_key="_env")
+    lifetime_seconds: int = Field(
+        600, env="PERMANENT_SESSION_LIFETIME", flask_config_key="_env"
+    )
+    session_type: SessionType = Field(
+        SessionType.filesystem,
+        env="FLASK_SESSION_TYPE",
+        flask_config_key="SESSION_TYPE",
+    )
+
+    @validator("secret_key")
+    def ensure_secret_key(cls, val: Optional[str]) -> str:
+        """
+        The secret key is always required. If it's not provided, it will be generated. This is usually fine as-is.
+        In a load-balanced environment, this should be a stored, shared secret for all environment
+        containers.
+        """
+        if val:
+            return val
+        characters = string.ascii_letters + string.digits
+        return "".join(secrets.choice(characters) for _ in range(24))
+
+
+class AuthSettings(FlaskConfigurationSettings):
+    """Stores settings related to authentication and SSL."""
+
+    uwca_cert_name: str = Field(..., env="UWCA_CERT_NAME")
+    uwca_cert_path: str = Field(..., env="UWCA_CERT_PATH")
+    saml_entity_id: str = Field(..., env="SAML_ENTITY_ID")
+    saml_acs_url: str = Field(..., env="SAML_ACS_URL")
+    use_test_idp: bool = Field(False, env="USE_TEST_IDP")
+
+
+class PWSSettings(FlaskConfigurationSettings):
+    """Stores settings related to the PWS API."""
+
+    pws_host: str = Field(..., env="PWS_HOST")
+    pws_default_path: str = Field(..., env="PWS_DEFAULT_PATH")
+
+
 @singleton
-class ApplicationConfig(BaseSettings):
+class ApplicationConfig(FlaskConfigurationSettings):
     """
     Base settings for the application. These can be provided by a dotenv file, environment variables, or directly
     during instantiation of this object. The exception is the `settings_dir`, which _must_ be provided; this is because
@@ -33,17 +179,29 @@ class ApplicationConfig(BaseSettings):
     """
 
     settings_dir: str
-    uwca_cert_name: str = Field(..., env="UWCA_CERT_NAME")
-    uwca_cert_path: str = Field(..., env="UWCA_CERT_PATH")
-    pws_host: str = Field(..., env="PWS_HOST")
-    pws_default_path: str = Field(..., env="PWS_DEFAULT_PATH")
     stage: str = Field(..., env="FLASK_ENV")
-    saml_entity_id: str = Field(..., env="SAML_ENTITY_ID")
-    saml_acs_url: str = Field(..., env="SAML_ACS_URL")
-    cookie_secret_key: Optional[str] = Field(None, env="COOKIE_SECRET_KEY")
-    use_test_idp: bool = Field(False, env="USE_TEST_IDP")
     build_id: Optional[str] = Field(None, env="BUILD_ID")
     start_time: datetime = Field(datetime.now())
+
+    # Aggregated Settings
+    pws_settings: PWSSettings = PWSSettings()
+    auth_settings: AuthSettings = AuthSettings()
+    session_settings: SessionSettings = SessionSettings()
+    redis_settings: Optional[RedisSettings]
+
+    @validator("redis_settings")
+    def validate_redis_settings(
+        cls, redis_settings: Optional[RedisSettings], values: Dict
+    ) -> Optional[RedisSettings]:
+        """Ensurues that, if redis is the selected session type, a redis setting object is created if it is not
+        already passed in."""
+        if (
+            cast(SessionSettings, values.get("session_settings")).session_type
+            == SessionType.redis
+            and not redis_settings
+        ):
+            return RedisSettings()
+        return redis_settings
 
     @property
     def uwca_certificate_path(self):
@@ -52,13 +210,6 @@ class ApplicationConfig(BaseSettings):
     @property
     def uwca_certificate_key(self):
         return os.path.join(self.uwca_cert_path, f"{self.uwca_cert_name}.crt")
-
-    @validator("cookie_secret_key")
-    def ensure_secret_key(cls, val: Optional[str]) -> str:
-        if val:
-            return val
-        characters = string.ascii_letters + string.digits
-        return "".join(secrets.choice(characters) for _ in range(24))
 
 
 class ApplicationConfigInjectorModule(Module):

--- a/husky_directory/blueprints/saml.py
+++ b/husky_directory/blueprints/saml.py
@@ -21,7 +21,7 @@ class SAMLBlueprint(Blueprint):
         self.idp_config = idp_config
         self.add_url_rule("/login", view_func=self.login, methods=["GET", "POST"])
         self.add_url_rule("/logout", view_func=self.logout)
-        self.app_settings = settings
+        self.auth_settings = settings.auth_settings
         self.logger = logger
 
     def process_saml_request(self, request: Request, session: LocalProxy, **kwargs):
@@ -41,8 +41,8 @@ class SAMLBlueprint(Blueprint):
     def login(self, request: Request, session: LocalProxy):
         session.clear()
         args = {
-            "entity_id": self.app_settings.saml_entity_id,
-            "acs_url": self.app_settings.saml_acs_url,
+            "entity_id": self.auth_settings.saml_entity_id,
+            "acs_url": self.auth_settings.saml_acs_url,
         }
 
         if request.method == "GET":

--- a/husky_directory/models/search.py
+++ b/husky_directory/models/search.py
@@ -35,6 +35,7 @@ class SearchDirectoryInput(DirectoryBaseModel):
     This is the input model for the /search API endpoint.
     Fields with `search_method=True` will be included in the drop down menu as search methods.
     """
+
     name: Optional[str] = Field(None, max_length=128, search_method=True)
     department: Optional[str] = Field(None, max_length=128, search_method=True)
     email: Optional[str] = Field(
@@ -48,7 +49,9 @@ class SearchDirectoryInput(DirectoryBaseModel):
     def search_methods(cls) -> List[str]:
         fields: Dict[str, Field] = cls.__fields__
         return [
-            f_name for f_name, f in fields.items() if f.field_info.extra.get('search_method')
+            f_name
+            for f_name, f in fields.items()
+            if f.field_info.extra.get("search_method")
         ]
 
     @property

--- a/husky_directory/models/search.py
+++ b/husky_directory/models/search.py
@@ -2,7 +2,7 @@
 Models for the DirectorySearchService.
 """
 import re
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Extra, Field, PydanticValueError, validator
 
@@ -31,14 +31,25 @@ class BoxNumberValueError(PydanticValueError):
 
 
 class SearchDirectoryInput(DirectoryBaseModel):
-    name: Optional[str] = Field(None, max_length=128)
-    department: Optional[str] = Field(None, max_length=128)
+    """
+    This is the input model for the /search API endpoint.
+    Fields with `search_method=True` will be included in the drop down menu as search methods.
+    """
+    name: Optional[str] = Field(None, max_length=128, search_method=True)
+    department: Optional[str] = Field(None, max_length=128, search_method=True)
     email: Optional[str] = Field(
-        None, max_length=256
+        None, max_length=256, search_method=True
     )  # https://tools.ietf.org/html/rfc5321#section-4.5.3
-    box_number: Optional[str]
-    phone: Optional[str]
+    box_number: Optional[str] = Field(None, search_method=True)
+    phone: Optional[str] = Field(None, search_method=True)
     population: PopulationType = PopulationType.employees
+
+    @classmethod
+    def search_methods(cls) -> List[str]:
+        fields: Dict[str, Field] = cls.__fields__
+        return [
+            f_name for f_name, f in fields.items() if f.field_info.extra.get('search_method')
+        ]
 
     @property
     def sanitized_phone(self) -> Optional[str]:

--- a/husky_directory/services/pws.py
+++ b/husky_directory/services/pws.py
@@ -22,14 +22,14 @@ class PersonWebServiceClient:
         logger: Logger,
         formatter: PrettyFormat,
     ):
-        uwca_cert_path = application_config.uwca_cert_path
-        uwca_cert_name = application_config.uwca_cert_name
+        uwca_cert_path = application_config.auth_settings.uwca_cert_path
+        uwca_cert_name = application_config.auth_settings.uwca_cert_name
         self.cert = RequestsCertificate(
             os.path.join(uwca_cert_path, f"{uwca_cert_name}.crt"),
             os.path.join(uwca_cert_path, f"{uwca_cert_name}.key"),
         )
-        self.host = application_config.pws_host
-        self.default_path = application_config.pws_default_path
+        self.host = application_config.pws_settings.pws_host
+        self.default_path = application_config.pws_settings.pws_default_path
         self.logger = logger
         self.formatter = formatter
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -210,6 +210,18 @@ Flask = "*"
 injector = ">=0.10.0"
 
 [[package]]
+name = "flask-session"
+version = "0.3.2"
+description = "Adds server-side session support to your Flask application"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+Flask = ">=0.8"
+cachelib = "*"
+
+[[package]]
 name = "gevent"
 version = "21.1.2"
 description = "Coroutine-based network library"
@@ -402,6 +414,7 @@ optional = false
 python-versions = ">=3.6.1"
 
 [package.dependencies]
+python-dotenv = {version = ">=0.10.4", optional = true, markers = "extra == \"dotenv\""}
 typing-extensions = ">=3.7.4.3"
 email-validator = {version = ">=1.0.3", optional = true, markers = "extra == \"email\""}
 
@@ -623,7 +636,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.9"
-content-hash = "38414355a6ac6f18f016618d3cbbb158dfbebf0de4fd191ad364bec5fe0d4b23"
+content-hash = "dae0e6f8ca308d8f86968772d4d12afe9adfe6261ac628a703d2f47a36407481"
 
 [metadata.files]
 appdirs = [
@@ -778,6 +791,10 @@ flask = [
 flask-injector = [
     {file = "Flask-Injector-0.12.3.tar.gz", hash = "sha256:82f5bf1245f6fbdbd19eeea4289fe35a3417a8ce05f710847a2f96b771a8085c"},
     {file = "Flask_Injector-0.12.3-py2.py3-none-any.whl", hash = "sha256:d0a5449b7d5f67f259a97e27dfb1111b48cfa418bce29d01c3beaa3493e248e4"},
+]
+flask-session = [
+    {file = "Flask-Session-0.3.2.tar.gz", hash = "sha256:0768e2bbf06f963ec1aa711bde7aa32dc39ff70f89b495d6db687d899eae4423"},
+    {file = "Flask_Session-0.3.2-py2.py3-none-any.whl", hash = "sha256:d75eb27f918421ccaf1ba86353348b84ecf07fc64ce40ff7ad05a190c4bf50f1"},
 ]
 gevent = [
     {file = "gevent-21.1.2-cp27-cp27m-macosx_10_14_x86_64.whl", hash = "sha256:2a9ae0a0fd956cbbc9c326b8f290dcad2b58acfb2e2732855fe1155fb110a04d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ python = ">=3.8,<3.9"
 Flask = "^1.1.2"
 injector = "^0.18.4"
 Flask-Injector = "^0.12.3"
-pydantic = {extras = ["email"], version = "^1.7.3"}
+pydantic = {extras = ["email", "dotenv"], version = "^1.8.1"}
 inflection = "^0.5.1"
 gunicorn = {extras = ["gevent"], version = "^20.0.4"}
 PyYAML = "^5.3.1"
@@ -18,6 +18,7 @@ requests = "^2.25.1"
 devtools = "^0.6.1"
 python-dotenv = "^0.15.0"
 uw-saml = {version = "^1.0.19"}
+Flask-Session = "^0.3.2"
 
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -41,7 +41,8 @@
 #
 # There are some options available for running this script; you will see them documented below.
 
-DOCKER_ORG=uwitiam
+REPO_HOST=gcr.io
+REPO_PROJECT=uwit-mci-iam
 APP_NAME=husky-directory
 SRC_DIR=husky_directory
 TST_DIR=tests
@@ -105,7 +106,7 @@ COMMIT_SHA=$(git log | head -n 1 | cut -f2 -d\ | cut -c 1-10)
 COMMIT_TAG="commit-${COMMIT_SHA}"
 conditional_echo "ℹ️ Commit tag is: ${COMMIT_TAG}"
 
-IMAGE_NAME="$DOCKER_ORG/$APP_NAME:$COMMIT_TAG"
+IMAGE_NAME="$REPO_HOST/$REPO_PROJECT/$APP_NAME:$COMMIT_TAG"
 PERSONAL_IMAGE="$DOCKER_ORG/$APP_NAME:personal-$PERSONAL_IMAGE_SUFFIX"
 
 if ! black --check $SRC_DIR $TST_DIR > /dev/null

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ def injector() -> Injector:
 @pytest.fixture
 def app_config(injector) -> ApplicationConfig:
     config = injector.get(ApplicationConfig)
-    config.use_test_idp = True
+    config.auth_settings.use_test_idp = True
     return config
 
 

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -22,18 +22,14 @@ class TestApplicationConfig:
 
     def test_app_config_has_fields(self):
         expected_field_names = {
-            "uwca_cert_path",
-            "uwca_cert_name",
-            "pws_host",
-            "pws_default_path",
             "settings_dir",
             "stage",
-            "cookie_secret_key",
-            "saml_acs_url",
-            "use_test_idp",
-            "saml_entity_id",
             "build_id",
             "start_time",
+            "auth_settings",
+            "redis_settings",
+            "session_settings",
+            "pws_settings",
         }
         assert set(self.app_config.dict().keys()) == expected_field_names
 


### PR DESCRIPTION
Also:

- Fixes "Population" showing up in dropdown field
- Refactors `app_config.py` to modularize settings (like we do for identity); support populating settings from dotenv files.

This doesn't actually do any redis integration or configuring of the sessions at the moment; it only sets up a local filesystem cache, which may or may not work for our dev server. Do not be surprised if the session issue still persists; this is just setting up some scaffolding.