### PR TITLE
Fix EncodeSans font family.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ __pycache__/
 *.py[cod]
 *$py.class
 nocommit.*  # Store arbitrary files in your local repo without committing them
-flask_session/  # Filesystem cache auto-created when running via pycharm
+flask_session/*  # Filesystem cache auto-created when running via pycharm
 
 # C extensions
 *.so

--- a/husky_directory/static/css/body.css
+++ b/husky_directory/static/css/body.css
@@ -1,47 +1,7 @@
 @import "structure.css";
 
-@font-face {
-  font-family: 'Encode Sans Compressed';
-  src: url('../assets/fonts/encodesanscondensed-400-regular-webfont.eot');
-  src: url('../assets/fonts/encodesanscondensed-400-regular-webfont.eot?#iefix') format('embedded-opentype'), url('../assets/fonts/encodesanscondensed-400-regular-webfont.woff') format('woff'), url('../assets/fonts/encodesanscondensed-400-regular-webfont.ttf') format('truetype'), url('../assets/fonts/encodesanscondensed-400-regular-webfont.svg#encodesanscondensed-400-regular-webfont') format('svg');
-  font-weight: 400;
-  font-style: normal;
-}
-@font-face {
-  font-family: 'Encode Sans Compressed';
-  src: url('../assets/fonts/encodesanscondensed-500-medium-webfont.eot');
-  src: url('../assets/fonts/encodesanscondensed-500-medium-webfont.eot?#iefix') format('embedded-opentype'), url('../assets/fonts/encodesanscondensed-500-medium-webfont.woff') format('woff'), url('../assets/fonts/encodesanscondensed-500-medium-webfont.ttf') format('truetype'), url('../assets/fonts/encodesanscondensed-500-medium-webfont.svg#encodesanscondensed-500-medium-webfont') format('svg');
-  font-weight: 500;
-  font-style: normal;
-}
-@font-face {
-  font-family: 'Encode Sans Compressed';
-  src: url('../assets/fonts/encodesanscompressed-600-semibold-webfont.eot');
-  src: url('../assets/fonts/encodesanscompressed-600-semibold-webfont.eot?#iefix') format('embedded-opentype'), url('../assets/fonts/encodesanscompressed-600-semibold-webfont.woff') format('woff'), url('../assets/fonts/encodesanscompressed-600-semibold-webfont.ttf') format('truetype'), url('../assets/fonts/encodesanscompressed-600-semibold-webfont.svg#encodesanscompressed-600-semibold-webfont') format('svg');
-  font-weight: 600;
-  font-style: normal;
-}
-@font-face {
-  font-family: 'Encode Sans Compressed';
-  src: url('../assets/fonts/encodesanscompressed-700-bold-webfont.eot');
-  src: url('../assets/fonts/encodesanscompressed-700-bold-webfont.eot?#iefix') format('embedded-opentype'), url('../assets/fonts/encodesanscompressed-700-bold-webfont.woff') format('woff'), url('../assets/fonts/encodesanscompressed-700-bold-webfont.ttf') format('truetype'), url('../assets/fonts/encodesanscompressed-700-bold-webfont.svg#encodesanscompressed-700-bold-webfont') format('svg');
-  font-weight: 700;
-  font-style: normal;
-}
-@font-face {
-  font-family: 'Encode Sans Compressed';
-  src: url('../assets/fonts/encodesanscompressed-800-extrabold-webfont.eot');
-  src: url('../assets/fonts/encodesanscompressed-800-extrabold-webfont.eot?#iefix') format('embedded-opentype'), url('../assets/fonts/encodesanscompressed-800-extrabold-webfont.woff') format('woff'), url('../assets/fonts/encodesanscompressed-800-extrabold-webfont.ttf') format('truetype'), url('../assets/fonts/encodesanscompressed-800-extrabold-webfont.svg#encodesanscompressed-800-extrabold-webfont') format('svg');
-  font-weight: 800;
-  font-style: normal;
-}
-@font-face {
-  font-family: 'Encode Sans Compressed';
-  src: url('../assets/fonts/encodesanscompressed-900-black-webfont.eot');
-  src: url('../assets/fonts/encodesanscompressed-900-black-webfont.eot?#iefix') format('embedded-opentype'), url('../assets/fonts/encodesanscompressed-900-black-webfont.woff') format('woff'), url('../assets/fonts/encodesanscompressed-900-black-webfont.ttf') format('truetype'), url('../assets/fonts/encodesanscompressed-900-black-webfont.svg#encodesanscompressed-900-black-webfont') format('svg');
-  font-weight: 900;
-  font-style: normal;
-}
+/* https://fonts.google.com/specimen/Encode+Sans+Condensed? */
+@import url('https://fonts.googleapis.com/css2?family=Encode+Sans+Condensed:wght@400;500;600;700;800;900&display=swap');
 
 .cblock input[type="radio"] {
 	margin-right: 10px;
@@ -51,12 +11,6 @@
 	display: block;
 }
 
-
-
-  font-family: sans-serif;
-  -ms-text-size-adjust: 100%;
-  -webkit-text-size-adjust: 100%;
-}
 body {
   margin: 0;
 }
@@ -344,7 +298,7 @@ h6,
 .h4,
 .h5,
 .h6 {
-  font-family: "Encode Sans Compressed", sans-serif;
+  font-family: "Encode Sans Condensed", sans-serif;
   font-weight: 800;
   line-height: 1.3;
   color: inherit;
@@ -2998,7 +2952,7 @@ h6,
 .h4,
 .h5,
 .h6 {
-  font-family: "Encode Sans Compressed", sans-serif;
+  font-family: "Encode Sans Condensed", sans-serif;
   font-weight: 800;
   line-height: 1.3;
   color: inherit;
@@ -3251,7 +3205,7 @@ iframe {
   margin: 40px 0 20px;
 }
 .intro {
-  font-family: "Encode Sans Compressed", sans-serif;
+  font-family: "Encode Sans Condensed", sans-serif;
   font-size: 23px;
   font-weight: 400;
   line-height: 1.5;
@@ -3299,7 +3253,7 @@ a.more:after {
   font-weight: 700;
 }
 .uw-body blockquote p {
-  font-family: "Encode Sans Compressed", sans-serif;
+  font-family: "Encode Sans Condensed", sans-serif;
   font-size: 21px;
 }
 .uw-body .uw-site-title {
@@ -3307,7 +3261,7 @@ a.more:after {
   top: -150px;
   left: 11px;
   color: #fff;
-  font-family: "Encode Sans Compressed", sans-serif;
+  font-family: "Encode Sans Condensed", sans-serif;
   font-size: 50px;
   line-height: 55px;
   font-weight: 900;
@@ -3324,7 +3278,7 @@ span.next-page a {
   padding: 10px 40px 10px 19px;
   text-transform: uppercase;
   background-color: #e8e3d3;
-  font-family: "Encode Sans Compressed", sans-serif;
+  font-family: "Encode Sans Condensed", sans-serif;
   font-weight: 800;
   color: #5a5a5a;
   display: inline-block;
@@ -3647,7 +3601,7 @@ a.uw-btn {
   padding: 13px 24px;
   text-transform: uppercase;
   background-color: #e8e3d3;
-  font-family: "Encode Sans Compressed", sans-serif;
+  font-family: "Encode Sans Condensed", sans-serif;
   font-weight: 800;
   color: #5a5a5a;
   display: inline-block;
@@ -3784,7 +3738,7 @@ body.error404 .woof {
   opacity: .6;
 }
 .uw-footer h4 {
-  font-family: "Encode Sans Compressed", sans-serif;
+  font-family: "Encode Sans Condensed", sans-serif;
   color: #fff;
   font-weight: 400;
   font-size: 20px;

--- a/husky_directory/static/css/mini.css
+++ b/husky_directory/static/css/mini.css
@@ -1,12 +1,5 @@
 @import "structure.css";
-
-@font-face {
-  font-family: 'Encode Sans Compressed';
-  src: url('../assets/fonts/encodesanscompressed-600-semibold-webfont.eot');
-  src: url('../assets/fonts/encodesanscompressed-600-semibold-webfont.eot?#iefix') format('embedded-opentype'), url('../assets/fonts/encodesanscompressed-600-semibold-webfont.woff') format('woff'), url('../assets/fonts/encodesanscompressed-600-semibold-webfont.ttf') format('truetype'), url('../assets/fonts/encodesanscompressed-600-semibold-webfont.svg#encodesanscompressed-600-semibold-webfont') format('svg');
-  font-weight: 600;
-  font-style: normal;
-}
+@import url('https://fonts.googleapis.com/css2?family=Encode+Sans+Condensed:wght@600&display=swap');
 
 /* Pulled from our CSS */
 
@@ -57,7 +50,7 @@
   list-style: none;
 }
 .uw-thinstrip ul.uw-thin-links li a {
-  font-family: "Encode Sans Compressed", sans-serif;
+  font-family: "Encode Sans Condensed", sans-serif;
   color: #fff;
   font-size: 14px;
   font-weight: 600;


### PR DESCRIPTION
Closes EDS-536

1. Let Google handle the browser compatibility issues by importing the family directly.
NB: Do you have any idea how hard it is to determine what font types IE10 supports?!

2. Change name to match Google's (`condensed` instead of `compressed`)

3. Remove a pretty glaring broken CSS block.