### PR TITLE
[EDS-565] Expand automated test cases (which required some bugs to be fixed too!)

### DIFF
--- a/husky_directory/templates/search.html
+++ b/husky_directory/templates/search.html
@@ -1,6 +1,6 @@
 {% set search_value = '' %}
 {% if request_input is not blank %}
-    {% set search_value = request_input['query'] %}
+    {% set search_value = request_input['render_query'] %}
 {% endif %}
 <div class="cblock row">
     <form action="/search" method="POST" name="dirform"
@@ -13,14 +13,13 @@
                        style="color:black; height:43px; z-index:0;" id="query"
                        {{ 'autofocus' if request_input is blank }}
                        name="query">
-                <input type="hidden" name="show_count" value="true">
                 <span class="input-group-btn">
-                                    <button class="btn search"
-                                            type="submit"
-                                            id="search"
-                                            style="background-color:white; border: thin solid #ddd;"
-                                    >Search</button>
-                                </span>
+                    <button class="btn search"
+                            type="submit"
+                            id="search"
+                            style="background-color:white; border: thin solid #ddd;"
+                    >Search</button>
+                </span>
             </div><!-- /input-group -->
             {% include "search_attribute_selection.html" %}
         </div>

--- a/husky_directory/templates/search_attribute_selection.html
+++ b/husky_directory/templates/search_attribute_selection.html
@@ -6,7 +6,7 @@
 #}
 {% set default_selection = "name" %}
 {% if request_input is not blank %}
-    {% set default_selection = request_input['method'] %}
+    {% set default_selection = request_input['render_method'] %}
 {% endif %}
 <select name="method"
         id="method" style="width: 220px; border: 1px solid #bbb; margin: 10px 0;">

--- a/husky_directory/templates/search_options.html
+++ b/husky_directory/templates/search_options.html
@@ -4,9 +4,9 @@
 {% endif %}
 <div id="search-population" class="col-md-3">
     <h3>Search options</h3>
-    <label for="employee-population-option">
+    <label for="population-option-employees">
         <input type="radio"
-               id="employee-population-option"
+               id="population-option-employees"
                name="population"
                value="employees"
                {% if requested_population is blank
@@ -17,9 +17,9 @@
         Faculty/Staff Only
     </label>
     {% if uwnetid is not blank %}
-        <label for="student-population-option">
+        <label for="population-option-students">
             <input type="radio"
-                   id="student-population-option"
+                   id="population-option-students"
                    name="population"
                    value="students"
                    {% if requested_population == 'students' %}
@@ -28,9 +28,9 @@
             >
             Students Only
         </label>
-        <label for="all-populations-option">
+        <label for="population-option-all">
             <input type="radio"
-                   id="all-populations-option"
+                   id="population-option-all"
                    name="population"
                    value="all"
                     {% if requested_population == 'all' %}
@@ -49,7 +49,7 @@
 
 {% set selected_length = 'summary' %}
 {% if request_input is not blank %}
-    {% set selected_length = request_input['length'] %}
+    {% set selected_length = request_input['render_length'] %}
 {% endif %}
 <div class="col-md-2">
     <h3>Kind of listing</h3>

--- a/husky_directory/templates/summary_results_table/scenario_population_block.html
+++ b/husky_directory/templates/summary_results_table/scenario_population_block.html
@@ -21,12 +21,37 @@ and then 1 or more rows of results. #}
         </td>
         <td valign="top">{{ data['email'] }}&nbsp;</td>
         <td>
-            <form action="/search" method="POST" name="moreform">
-                <input type="hidden" name="name" value="{{ data['name'] }}">
-                <input type="hidden" name="length" value="full">
+            {% set form_id = "more-form-" ~ loop.index  %}
+            <form action="/search" id="{{ form_id }}"
+                  method="POST" name="{{ form_id }}">
+                <!-- We are running a different query than we are displaying in the
+                  -- UI here. We don't want to actually reset the UI with
+                  -- the values we're using for our search.
+                  -- Therefore, we set the "return_" overrides to carry the
+                  -- user's actual query, so that they don't have to
+                  -- re-type it in, or use their back button.
+                  -->
+                <input id="{{ form_id }}-query"
+                       type="hidden" name="query" value="{{ data['name'] }}">
+                <input id="{{ form_id }}-render-query" type="hidden"
+                       name="render_query" value="{{ request_input['query'] }}">
+                <!-- TODO: Use the user href query instead, see EDS-566 -->
+                <input id="{{ form_id }}-method"
+                       type="hidden" name="method" value="name">
+                <input id="{{ form_id }}-render-method" type="hidden"
+                       name="render_method" value="{{ request_input['method'] }}">
+                <input id="{{ form_id }}-length"
+                       type="hidden" name="length" value="full">
+                <input id="{{ form_id }}-render-length"
+                       type="hidden" name="render_length"
+                       value="{{ request_input['length'] }}">
+                <!-- This option doesn't affect the query so can stay as-is -->
+                <input id="{{ form_id }}-population"
+                       type="hidden" name="population"
+                       value="{{ request_input['population'] }}">
                 <input class="btn btn-primary"
                        type="submit"
-                       name="expand0" value="More">
+                       name="expand-{{ loop.index }}" value="More">
             </form>
         </td>
     </tr>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,7 +117,12 @@ def mock_people(generate_person):
                         touch_dials=["+19999499911"],
                         emails=["dawg@uw.edu"],
                     )
-                )
+                ),
+                student=StudentPersonAffiliation(
+                    directory_listing=StudentDirectoryListing(
+                        publish_in_directory=True, phone="19999674222"
+                    )
+                ),
             )
         )
 
@@ -345,7 +350,7 @@ class HTMLValidator:
         if assert_expected_ != result:
             raise AssertionError(
                 f"Expected {'not ' if not assert_expected_ else ''}"
-                f"to find tags with search_text matching {search_text}"
+                f"to find a <{target_tag}> tag with text including '{search_text}' in {self.html}"
             )
         return False
 
@@ -360,10 +365,10 @@ class HTMLValidator:
 
     def has_student_search_options(self, assert_=True, assert_expected_=True) -> bool:
         students_only = self.html.find(
-            "label", attrs={"for": "student-population-option"}
+            "label", attrs={"for": "population-option-students"}
         )
         all_populations = self.html.find(
-            "label", attrs={"for": "all-populations-option"}
+            "label", attrs={"for": "population-option-all"}
         )
         result = bool(students_only and all_populations)
         if not assert_:


### PR DESCRIPTION
- Renames `SearchDirectorySimpleInput` to `SearchDirectoryFormInput`
- Fixes "more" links not always preserving user selections on re-render by adding `render_` override fields to `SearchDirectoryFormInput`, so that the "More" buttons can search one thing, but instruct the server to render another. This gives us parity with the existing directory More behavior. However, see also EDS-566.
- Adds a combinatoric test suite for all possible form options, to verify that in all cases, the resulting page is rendered as we expect. 

With the current combination of parameters for that test, there are 60 total tests generated and run that now all pass. There will be lots more once "Department" is supported and added to the "method" parameter list.