### PR TITLE
[EDS-564] Adds vcard support to the cloud-native directory

### DIFF
--- a/husky_directory/blueprints/search.py
+++ b/husky_directory/blueprints/search.py
@@ -1,19 +1,22 @@
+from base64 import b64decode
 from logging import Logger
 from typing import Optional
 
-from flask import Blueprint, Request, jsonify, redirect, render_template
+from flask import Blueprint, Request, jsonify, render_template, send_file
 from inflection import humanize, underscore
-from injector import inject, singleton
+from injector import Injector, inject, singleton
 from pydantic import ValidationError
+from werkzeug.exceptions import BadRequest
 from werkzeug.local import LocalProxy
 
 from husky_directory.models.search import (
     DirectoryBaseModel,
+    SearchDirectoryFormInput,
     SearchDirectoryInput,
     SearchDirectoryOutput,
-    SearchDirectoryFormInput,
 )
 from husky_directory.services.search import DirectorySearchService
+from husky_directory.services.vcard import VCardService
 
 
 class ErrorModel(DirectoryBaseModel):
@@ -31,24 +34,70 @@ class RenderingContext(DirectoryBaseModel):
 @singleton
 class SearchBlueprint(Blueprint):
     @inject
-    def __init__(self, logger: Logger):
+    def __init__(self, logger: Logger, injector: Injector):
         super().__init__("search", __name__, url_prefix="/search")
+        self.injector = injector
         self.logger = logger
         self.add_url_rule("/", view_func=self.get, methods=("GET",))
         self.add_url_rule("/", view_func=self.render, methods=("POST",))
+        # When no output format is provided, defaults to html
+        self.add_url_rule(
+            "/person/<href_token>",
+            defaults={"output_format": "html"},
+            view_func=self.get_person,
+            methods=("GET", "POST"),
+        )
+        # /person/{token}/vcard
+        # defaults to 'html' (above)
+        self.add_url_rule(
+            "/person/<href_token>/<output_format>",
+            view_func=self.get_person,
+            methods=("GET", "POST"),
+        )
+
+    @property
+    def vcard_service(self):
+        # Create an ad-hoc instance so that it has access to
+        # request session parameters (as opposed to a
+        # singleton instance)
+        return self.injector.get(VCardService)
 
     def get(self, request: Request, search_service: DirectorySearchService):
-        # In this case, we should assume a user just typed in the /search, which is fine.
-        if (
-            request.content_type
-            not in ("search_text/javascript", "application/javascript")
-            and not request.args
-        ):
-            return redirect("/")
+        """
+        An API call, returning JSON output. Not actively used by
+        any existing flows, but useful for testing/debugging,
+        and may be useful to customers. Uses the SearchDirectoryInput model
+        by way of query parameters.
+            directory.uw.edu/search?name=foo&population=employees
+
+        Returns a jsonified instance of SearchDirectoryOutput
+        """
         request_input = SearchDirectoryInput.parse_obj(request.args)
         self.logger.info(f"searching for {request_input}")
         request_output = search_service.search_directory(request_input)
         return jsonify(request_output.dict(by_alias=True, exclude_none=True))
+
+    def get_person(
+        self,
+        request: Request,
+        href_token: str,
+        output_format: str,
+    ):
+        """
+        Given a specific person HREF, retrieves the person and returns their results.
+        For this, the population is always "all," but student data will be excluded
+        for requests that are not authenticated.
+        """
+        if output_format == "vcard":
+            return self.get_person_vcard(href_token)
+        else:  # We can expand this as needed.
+            raise BadRequest("Invalid output type requested")
+
+    def get_person_vcard(self, href_token: str):
+        vcard_stream = self.vcard_service.get_vcard(
+            b64decode(href_token.encode("UTF-8")).decode("UTF-8")
+        )
+        return send_file(vcard_stream, mimetype="text/vcard")
 
     @staticmethod
     def render(
@@ -76,7 +125,6 @@ class SearchBlueprint(Blueprint):
                 context.status_code = 400
                 bad_fields = [humanize(underscore(err["loc"][0])) for err in e.errors()]
                 context.error = ErrorModel(msg=f"Invalid {', '.join(bad_fields)}")
-                logger.error("WTF")
             else:
                 context.status_code = 500
                 context.error = ErrorModel(

--- a/husky_directory/models/pws.py
+++ b/husky_directory/models/pws.py
@@ -153,17 +153,20 @@ class PersonAffiliations(PWSBaseModel):
     )
 
 
-class PersonOutput(PWSBaseModel):
-    display_name: str = Field(..., alias="DisplayName")
-    affiliations: PersonAffiliations = Field(
-        PersonAffiliations(), alias="PersonAffiliations"
-    )
-    registered_name: str
-    registered_surname: str
+class NamedIdentity(PWSBaseModel):
+    display_name: Optional[str] = Field(..., alias="DisplayName")
+    registered_name: Optional[str]
+    registered_surname: Optional[str]
     registered_first_middle_name: Optional[str]
     preferred_first_name: Optional[str]
     preferred_middle_name: Optional[str]
     preferred_last_name: Optional[str]
+
+
+class PersonOutput(NamedIdentity):
+    affiliations: PersonAffiliations = Field(
+        PersonAffiliations(), alias="PersonAffiliations"
+    )
     pronouns: Optional[str]
     regid: Optional[str] = Field(None, alias="UWRegID")
     netid: Optional[str] = Field(None, alias="UWNetID")

--- a/husky_directory/models/search.py
+++ b/husky_directory/models/search.py
@@ -2,6 +2,7 @@
 Models for the DirectorySearchService.
 """
 from __future__ import annotations
+import base64
 import re
 from typing import Dict, List, Optional
 
@@ -33,6 +34,7 @@ class SearchDirectoryFormInput(DirectoryBaseModel):
     method: str = "name"
     query: str = ""
     population: PopulationType = PopulationType.employees
+    include_test_identities: bool = False
     length: ResultDetail = ResultDetail.summary
 
     # render_ fields are provided as a way to search one thing,
@@ -151,6 +153,11 @@ class Person(DirectoryBaseModel):
     email: Optional[str]
     box_number: Optional[str]
     department: Optional[str]
+    href: str
+
+    @validator("href")
+    def b64_encode_href(cls, value: str) -> str:
+        return base64.b64encode(value.encode("UTF-8")).decode("UTF-8")
 
 
 class DirectoryQueryPopulationOutput(DirectoryBaseModel):

--- a/husky_directory/models/vcard.py
+++ b/husky_directory/models/vcard.py
@@ -1,0 +1,28 @@
+from enum import Enum
+from typing import List, Optional
+
+from husky_directory.models.base import DirectoryBaseModel
+
+
+class VCardPhoneType(Enum):
+    text = "text"
+    voice = "voice"
+    fax = "fax"
+    cell = "cell"
+    pager = "pager"
+    textphone = "textphone"  # TDD
+
+
+class VCardPhone(DirectoryBaseModel):
+    types: List[VCardPhoneType]
+    value: str
+
+
+class VCard(DirectoryBaseModel):
+    last_name: str
+    name_extras: List[str] = []
+    display_name: str
+    titles: List[str] = []
+    departments: List[str] = []
+    email: Optional[str]
+    phones: List[VCardPhone] = []

--- a/husky_directory/services/search.py
+++ b/husky_directory/services/search.py
@@ -1,30 +1,22 @@
 from __future__ import annotations
 
 from logging import Logger
-from typing import Dict, List, Optional, Set
+from typing import List
 
 from devtools import PrettyFormat
 from injector import inject, singleton
-from werkzeug.local import LocalProxy
 
-from husky_directory.models.enum import PopulationType
-from husky_directory.models.pws import (
-    EmployeePersonAffiliation,
-    ListPersonsOutput,
-    PersonOutput,
-    StudentPersonAffiliation,
-)
 from husky_directory.models.search import (
-    DirectoryBaseModel,
-    DirectoryQueryPopulationOutput,
     DirectoryQueryScenarioOutput,
-    Person,
-    PhoneContactMethods,
     SearchDirectoryInput,
     SearchDirectoryOutput,
 )
 from husky_directory.services.pws import PersonWebServiceClient
 from husky_directory.services.query_generator import SearchQueryGenerator
+from husky_directory.services.translator import (
+    ListPersonsOutputTranslator,
+    PersonOutputFilter,
+)
 
 
 @singleton
@@ -59,7 +51,7 @@ class DirectorySearchService:
             pws_output = self._pws.list_persons(query)
             aggregate_output = pws_output
             while pws_output.next and pws_output.next.href:
-                pws_output = self._pws.get_next(pws_output.next.href)
+                pws_output = self._pws.get_explicit_href(pws_output.next.href)
                 aggregate_output.persons.extend(pws_output.persons)
 
             scenario_output = DirectoryQueryScenarioOutput(
@@ -71,172 +63,3 @@ class DirectorySearchService:
             scenarios.append(scenario_output)
 
         return SearchDirectoryOutput(scenarios=scenarios)
-
-
-class PersonOutputFilter(DirectoryBaseModel):
-    allowed_populations: List[PopulationType] = [PopulationType.employees]
-    include_test_identities: bool = False
-    duplicate_netids: Set[str] = set()
-
-    def population_is_allowed(self, population: PopulationType) -> bool:
-        return (
-            "all" in self.allowed_populations
-            or population.value in self.allowed_populations
-        )
-
-
-class ListPersonsOutputTranslator:
-    """
-    Translates PWS API output in to Directory API output.
-    """
-
-    @inject
-    def __init__(self, session: LocalProxy):
-        self._session = session
-
-    @property
-    def session(self) -> LocalProxy:
-        return self._session
-
-    @property
-    def current_request_is_authenticated(self) -> bool:
-        return bool(self.session.get("uwnetid"))
-
-    def filter_person(
-        self, person: PersonOutput, person_filter_paramters: PersonOutputFilter
-    ) -> bool:
-        """
-        Given a PersonOutput, determines whether the result is valid to return to the front-end. This is needed
-        because PWS does not provide query support for all fields, in particular the 'publish_in_directory' and the
-        'whitepages_publish' fields. If _translate_pws_list_persons_output() is broken out into its own service,
-        this should probably go along with it.
-
-        :returns: True if the user should be included in the output, or False if they should be pruned.
-        """
-        if not all(
-            [
-                person.netid,  # Only publish identities with netids
-                person.whitepages_publish,  # that want to be published
-                # and that we're not already returning
-                person.netid not in person_filter_paramters.duplicate_netids,
-            ]
-        ):
-            return False
-
-        # Only include test identities if explicitly asked
-        if (
-            person.is_test_entity
-            and not person_filter_paramters.include_test_identities
-        ):
-            return False
-
-        if person.affiliations.student:
-            if not all(
-                [
-                    # ensure the request is authenticated
-                    self.current_request_is_authenticated,
-                    # ensure the user requested student data
-                    person_filter_paramters.population_is_allowed(
-                        PopulationType.students
-                    ),
-                    # Ensure the identity has elected to be published
-                    person.affiliations.student.directory_listing.publish_in_directory,
-                ]
-            ):
-                person.affiliations.student = None
-
-        if (
-            person.affiliations.employee
-        ):  # Similar to above, minus the current_user check
-            if not all(
-                [
-                    person_filter_paramters.population_is_allowed(
-                        PopulationType.employees
-                    ),
-                    person.affiliations.employee.directory_listing.publish_in_directory,
-                ]
-            ):
-                person.affiliations.employee = None
-
-        # If we've pruned all the valid affiliations for this person,
-        # then we won't include them in the results.
-        if not any([person.affiliations.student, person.affiliations.employee]):
-            return False
-
-        return True
-
-    def _resolve_phones(
-        self,
-        employee_affiliation: Optional[EmployeePersonAffiliation],
-        student_affiliation: Optional[StudentPersonAffiliation],
-    ) -> PhoneContactMethods:
-        model = PhoneContactMethods()
-        if employee_affiliation:
-            model = model.copy(
-                update=employee_affiliation.directory_listing.dict(
-                    include={
-                        "phones",
-                        "pagers",
-                        "voice_mails",
-                        "touch_dials",
-                        "faxes",
-                        "mobiles",
-                    },
-                )
-            )
-        if student_affiliation:
-            model.phones.append(student_affiliation.directory_listing.phone)
-        return model
-
-    def translate_scenario(
-        self,
-        request_output: ListPersonsOutput,
-        person_filter_parameters: PersonOutputFilter,
-    ) -> Dict[PopulationType, DirectoryQueryPopulationOutput]:
-        # TODO: positions, departments, majors -- fill in jira gaps
-
-        results = {
-            PopulationType.employees: DirectoryQueryPopulationOutput(
-                population=PopulationType.employees
-            ),
-            PopulationType.students: DirectoryQueryPopulationOutput(
-                population=PopulationType.students
-            ),
-        }
-
-        def filter_(person_) -> bool:
-            """A small shim around the class method to include the user-requested filters"""
-            return self.filter_person(person_, person_filter_parameters)
-
-        # Streams the list and iterates, excluding entries we don't want to return
-        for person in filter(filter_, request_output.persons):
-            student = person.affiliations.student
-            employee = person.affiliations.employee
-
-            person_args = {
-                "name": person.display_name,
-            }
-            person_args.update(
-                {
-                    "phone_contacts": self._resolve_phones(
-                        employee_affiliation=employee, student_affiliation=student
-                    )
-                }
-            )
-
-            result = Person.parse_obj(person_args)
-
-            if employee:
-                if employee.directory_listing.emails:
-                    result.email = employee.directory_listing.emails[0]
-                results[PopulationType.employees].people.append(result)
-
-            if student:
-                # Email will usually be the same, but just in case, we'll prefer the
-                # employee email address and not overwrite it with the student's if
-                # it's already set.
-                if not result.email:
-                    result.email = student.directory_listing.email
-                results[PopulationType.students].people.append(result)
-            person_filter_parameters.duplicate_netids.add(person.netid)
-        return results

--- a/husky_directory/services/translator.py
+++ b/husky_directory/services/translator.py
@@ -1,0 +1,185 @@
+from typing import Dict, List, Optional, Set
+
+from injector import inject
+from werkzeug.local import LocalProxy
+
+from husky_directory.models.base import DirectoryBaseModel
+from husky_directory.models.enum import PopulationType
+from husky_directory.models.pws import (
+    EmployeePersonAffiliation,
+    ListPersonsOutput,
+    PersonOutput,
+    StudentPersonAffiliation,
+)
+from husky_directory.models.search import (
+    DirectoryQueryPopulationOutput,
+    Person,
+    PhoneContactMethods,
+)
+
+
+class PersonOutputFilter(DirectoryBaseModel):
+    allowed_populations: List[PopulationType] = [PopulationType.employees]
+    include_test_identities: bool = False
+    duplicate_netids: Set[str] = set()
+
+    def population_is_allowed(self, population: PopulationType) -> bool:
+        return (
+            "all" in self.allowed_populations
+            or population.value in self.allowed_populations
+        )
+
+
+class ListPersonsOutputTranslator:
+    """
+    Translates PWS API output in to Directory API output.
+    """
+
+    @inject
+    def __init__(self, session: LocalProxy):
+        self._session = session
+
+    @property
+    def session(self) -> LocalProxy:
+        return self._session
+
+    @property
+    def current_request_is_authenticated(self) -> bool:
+        return bool(self.session.get("uwnetid"))
+
+    def filter_person(
+        self, person: PersonOutput, person_filter_paramters: PersonOutputFilter
+    ) -> bool:
+        """
+        Given a PersonOutput, determines whether the result is valid to return to the front-end. This is needed
+        because PWS does not provide query support for all fields, in particular the 'publish_in_directory' and the
+        'whitepages_publish' fields. If _translate_pws_list_persons_output() is broken out into its own service,
+        this should probably go along with it.
+
+        :returns: True if the user should be included in the output, or False if they should be pruned.
+        """
+        if not all(
+            [
+                person.netid,  # Only publish identities with netids
+                person.whitepages_publish,  # that want to be published
+                # and that we're not already returning
+                person.netid not in person_filter_paramters.duplicate_netids,
+            ]
+        ):
+            return False
+
+        # Only include test identities if explicitly asked
+        if (
+            person.is_test_entity
+            and not person_filter_paramters.include_test_identities
+        ):
+            return False
+
+        if person.affiliations.student:
+            if not all(
+                [
+                    # ensure the request is authenticated
+                    self.current_request_is_authenticated,
+                    # ensure the user requested student data
+                    person_filter_paramters.population_is_allowed(
+                        PopulationType.students
+                    ),
+                    # Ensure the identity has elected to be published
+                    person.affiliations.student.directory_listing.publish_in_directory,
+                ]
+            ):
+                person.affiliations.student = None
+
+        if (
+            person.affiliations.employee
+        ):  # Similar to above, minus the current_user check
+            if not all(
+                [
+                    person_filter_paramters.population_is_allowed(
+                        PopulationType.employees
+                    ),
+                    person.affiliations.employee.directory_listing.publish_in_directory,
+                ]
+            ):
+                person.affiliations.employee = None
+
+        # If we've pruned all the valid affiliations for this person,
+        # then we won't include them in the results.
+        if not any([person.affiliations.student, person.affiliations.employee]):
+            return False
+
+        return True
+
+    def _resolve_phones(
+        self,
+        employee_affiliation: Optional[EmployeePersonAffiliation],
+        student_affiliation: Optional[StudentPersonAffiliation],
+    ) -> PhoneContactMethods:
+        model = PhoneContactMethods()
+        if employee_affiliation:
+            model = model.copy(
+                update=employee_affiliation.directory_listing.dict(
+                    include={
+                        "phones",
+                        "pagers",
+                        "voice_mails",
+                        "touch_dials",
+                        "faxes",
+                        "mobiles",
+                    },
+                )
+            )
+        if student_affiliation:
+            model.phones.append(student_affiliation.directory_listing.phone)
+        return model
+
+    def translate_scenario(
+        self,
+        request_output: ListPersonsOutput,
+        person_filter_parameters: PersonOutputFilter,
+    ) -> Dict[PopulationType, DirectoryQueryPopulationOutput]:
+        # TODO: positions, departments, majors -- fill in jira gaps
+
+        results = {
+            PopulationType.employees: DirectoryQueryPopulationOutput(
+                population=PopulationType.employees
+            ),
+            PopulationType.students: DirectoryQueryPopulationOutput(
+                population=PopulationType.students
+            ),
+        }
+
+        def filter_(person_) -> bool:
+            """A small shim around the class method to include the user-requested filters"""
+            return self.filter_person(person_, person_filter_parameters)
+
+        # Streams the list and iterates, excluding entries we don't want to return
+        for person in filter(filter_, request_output.persons):
+            student = person.affiliations.student
+            employee = person.affiliations.employee
+
+            person_args = {"name": person.display_name, "href": person.href}
+            person_args.update(
+                {
+                    "phone_contacts": self._resolve_phones(
+                        employee_affiliation=employee, student_affiliation=student
+                    )
+                }
+            )
+
+            result = Person.parse_obj(person_args)
+
+            if employee:
+                if employee.directory_listing.emails:
+                    result.email = employee.directory_listing.emails[0]
+                results[PopulationType.employees].people.append(result)
+
+            if student:
+                # Email will usually be the same, but just in case, we'll prefer the
+                # employee email address and not overwrite it with the student's if
+                # it's already set.
+                if not result.email:
+                    result.email = student.directory_listing.email
+                results[PopulationType.students].people.append(result)
+            person_filter_parameters.duplicate_netids.add(person.netid)
+        return results

--- a/husky_directory/services/vcard.py
+++ b/husky_directory/services/vcard.py
@@ -1,0 +1,143 @@
+from collections import defaultdict
+from io import BytesIO
+from typing import Dict, NoReturn, Set
+
+from flask import Flask, render_template
+from injector import Injector, inject
+from werkzeug.exceptions import Forbidden
+from werkzeug.local import LocalProxy
+
+from husky_directory.models.enum import PopulationType
+from husky_directory.models.pws import PersonOutput
+from husky_directory.models.vcard import VCard, VCardPhone, VCardPhoneType
+from husky_directory.services.pws import PersonWebServiceClient
+from husky_directory.services.translator import (
+    ListPersonsOutputTranslator,
+    PersonOutputFilter,
+)
+
+
+class VCardService:
+    """Generates vcards from PWS output."""
+    @inject
+    def __init__(
+        self,
+        pws: PersonWebServiceClient,
+        app: Flask,
+        injector: Injector,
+    ):
+        self.pws = pws
+        self.flask = app
+        self.injector = injector
+
+    @property
+    def request_is_authenticated(self):
+        # Lazily bound to constrain request scopes
+        session = self.injector.get(LocalProxy)
+        return bool(session.get("uwnetid"))
+
+    @property
+    def translator(self) -> ListPersonsOutputTranslator:
+        # Lazily bound to constrain request scopes
+        return self.injector.get(ListPersonsOutputTranslator)
+
+    @staticmethod
+    def set_employee_vcard_attrs(vcard: VCard, person: PersonOutput) -> NoReturn:
+        """
+        Based on a person's employee attributes, sets appropriate vcard values.
+        For people who are both students and employees, employee phones and email
+        selections will override student selections, if they differ.
+        """
+        employee = person.affiliations.employee
+        if not employee or not employee.directory_listing:
+            return {}
+        employee = employee.directory_listing
+
+        for position in employee.positions:
+            vcard.titles.append(position.title)
+            vcard.departments.append(position.department)
+
+        phones: Dict[str, Set[VCardPhoneType]] = defaultdict(lambda: set())
+
+        for pager in employee.pagers:
+            phones[pager].add(VCardPhoneType.pager)
+        for tdd in employee.touch_dials:
+            phones[tdd].add(VCardPhoneType.textphone)
+        for fax in employee.faxes:
+            phones[fax].add(VCardPhoneType.fax)
+        for phone in employee.mobiles:
+            phones[phone].add(VCardPhoneType.text)
+            phones[phone].add(VCardPhoneType.voice)
+        for phone in employee.voice_mails + employee.phones:
+            phones[phone].add(VCardPhoneType.voice)
+
+        # If student phones exist, we prefer employee phones, so we overwrite.
+        if phones:
+            vcard.phones = [
+                # Sort the types based on their stringified values
+                # so that our vcard ordering is deterministic.
+                VCardPhone(
+                    types=sorted(list(types), key=lambda t: t.value), value=phone
+                )
+                for phone, types in phones.items()
+            ]
+
+        # If student email exists, we prefer employee email (in case they are different),
+        # so we overwrite.
+        if employee.emails:
+            vcard.email = employee.emails[0]
+
+    @staticmethod
+    def set_student_vcard_attrs(vcard: VCard, person: PersonOutput) -> NoReturn:
+        student = person.affiliations.student
+        # If there is no student directory data, then return an empty dict.
+        if not student or not student.directory_listing:
+            return {}
+        student = student.directory_listing
+        vcard.departments.extend([dept for dept in student.departments])
+
+        if student.phone:
+            vcard.phones.append(
+                VCardPhone(types=[VCardPhoneType.voice], value=student.phone)
+            )
+        if student.email:
+            vcard.email = student.email
+
+        if student.class_level:
+            vcard.titles.append(student.class_level)
+
+    def get_vcard(self, href: str) -> BytesIO:
+        person = self.pws.get_explicit_href(href, output_type=PersonOutput)
+
+        if not self.translator.filter_person(
+            # We set "PopulationType.all" here because when searching
+            # for a specific person, we expect to get all of their attributes.
+            # The filter will exclude student data if the requester is not
+            # authenticated.
+            person,
+            PersonOutputFilter(allowed_populations=[PopulationType.all]),
+        ):  # This is the case if the resulting person is a student,
+            # but the request isn't authenticated
+            raise Forbidden(href)
+
+        # "Mary Shelly" becomes ["Shelley", "Mary"]
+        name_parts = list(reversed(person.display_name.split()))
+        vcard = VCard.construct(
+            last_name=name_parts.pop(0),  # "Shelley"
+            name_extras=name_parts,  # ["Mary"]
+            display_name=person.display_name,  # "Mary Shelley"
+        )
+        self.set_student_vcard_attrs(vcard, person)
+        self.set_employee_vcard_attrs(vcard, person)
+        # Render the vcard template with the user's data,
+        content = render_template("vcard.vcf.jinja2", **vcard.dict())
+        # Remove all the extra lines that jinja2 leaves in there. (ugh.)
+        content = "\n".join(
+            filter(lambda line: bool(line.strip()), content.split("\n"))
+        )
+        # Create a file-like object to send to the client
+        file_ = BytesIO()
+        file_.write(content.encode("UTF-8"))
+        file_.seek(0)
+
+        return file_

--- a/husky_directory/services/vcard.py
+++ b/husky_directory/services/vcard.py
@@ -19,6 +19,7 @@ from husky_directory.services.translator import (
 
 class VCardService:
     """Generates vcards from PWS output."""
+
     @inject
     def __init__(
         self,

--- a/husky_directory/templates/full_results.html
+++ b/husky_directory/templates/full_results.html
@@ -17,6 +17,11 @@
                         {% endif %}
                     {% endfor %}
                 </ul>
+                <button class="btn btn-primary" name="vcard-{{ loop.index }}">
+                    <a href="/search/person/{{ data['href'] }}/vcard"
+                       style="color:white;"
+                       download="{{ data['name'] }}.vcf">Download vcard</a>
+                </button>
             {% endfor %}
         {% endfor %}
         </p>

--- a/husky_directory/templates/vcard.vcf.jinja2
+++ b/husky_directory/templates/vcard.vcf.jinja2
@@ -6,17 +6,15 @@
     Model: husky_directory.models.vcard.VCard
 #}
 BEGIN:VCARD
-{# woofington;dawg;husky #}
-N:{{ last_name }};{% for e in name_extras %}{{ e }}{{
-        ';' if not loop.last else '' }}
-{% endfor %}
+{# "Husky Dawg Woofington" becomes "woofington;husky;dawg" #}
+N:{{ last_name }};{% for e in name_extras %}{{ e }}{{';' if not loop.last else '' }}{% endfor %}
 {# Husky Dawg Woofington #}
 FN:{{ display_name }}
 {% for title in titles %}
 TITLE:{{ title }}
 {% endfor %}
 {% for dept in departments %}
-ORG:{{ dept }}
+ORG:University of Washington;{{ dept }}
 {% endfor %}
 {% if not email is blank %}
 {# EMAIL;type=INTERNET;type=WORK:dawg@uw.edu #}

--- a/husky_directory/templates/vcard.vcf.jinja2
+++ b/husky_directory/templates/vcard.vcf.jinja2
@@ -1,0 +1,30 @@
+{#
+    Do not adhere to conventional indendation in this file.
+    Line breaks for long lines must only happen _inside_ jinja blocks.
+    field must be on a single line, with no indents.
+    Specification: https://tools.ietf.org/html/rfc6350
+    Model: husky_directory.models.vcard.VCard
+#}
+BEGIN:VCARD
+{# woofington;dawg;husky #}
+N:{{ last_name }};{% for e in name_extras %}{{ e }}{{
+        ';' if not loop.last else '' }}
+{% endfor %}
+{# Husky Dawg Woofington #}
+FN:{{ display_name }}
+{% for title in titles %}
+TITLE:{{ title }}
+{% endfor %}
+{% for dept in departments %}
+ORG:{{ dept }}
+{% endfor %}
+{% if not email is blank %}
+{# EMAIL;type=INTERNET;type=WORK:dawg@uw.edu #}
+EMAIL;type=WORK:{{ email }}
+{% endif %}
+{% for phone in phones %}
+{# TEL;type="pager,voice":5558675309 #}
+TEL;type="{% for pt in phone['types'] %}{{ pt }}{{
+        ',' if not loop.last else '' }}{% endfor %}":{{ phone['value'] }}
+{% endfor %} {# phone in phones #}
+END:VCARD

--- a/scripts/validate-development-image.sh
+++ b/scripts/validate-development-image.sh
@@ -22,7 +22,7 @@ then
   FAIL=1
 fi
 
-CMD="pytest $TST_DIR --cov ${SRC_DIR}/husky_directory --cov-report term-missing --cov-report html --cov-fail-under 97"
+CMD="pytest $TST_DIR --cov ${SRC_DIR}/husky_directory --cov-report term-missing --cov-report html --cov-fail-under 98"
 
 echo $CMD
 if ! $CMD

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 import os
+import random
 import re
+import string
 from contextlib import contextmanager
 from typing import Any, Optional
 
@@ -55,6 +57,8 @@ def app(
 
 @pytest.fixture
 def generate_person():
+    random_string = "".join(random.choice(string.ascii_lowercase) for _ in range(24))
+
     def inner(**attrs: Any) -> PersonOutput:
         default = PersonOutput(
             display_name="Ada Lovelace",
@@ -64,6 +68,7 @@ def generate_person():
             whitepages_publish=True,
             is_test_entity=False,
             netid="ada",
+            href=f"person/{random_string}",
         )
         return default.copy(update=attrs)
 

--- a/tests/services/test_pws.py
+++ b/tests/services/test_pws.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 import requests
 
-from husky_directory.models.pws import ListPersonsInput
+from husky_directory.models.pws import ListPersonsInput, ListPersonsOutput
 from husky_directory.services.pws import PersonWebServiceClient
 
 
@@ -21,11 +21,13 @@ class TestPersonWebServiceClient:
     def test_pws_url(self):
         assert self.client.pws_url.endswith("identity/v2")
 
-    def test_get_next(self):
+    def test_get_explicit_href(self):
         expected_url = f"{self.client.pws_url}/foobar"
 
-        self.client.get_next("/identity/v2/foobar")
-        self.mock_send_request.assert_called_once_with(expected_url)
+        self.client.get_explicit_href("/identity/v2/foobar")
+        self.mock_send_request.assert_called_once_with(
+            expected_url, output_type=ListPersonsOutput
+        )
 
     def test_list_persons(self):
         request_input = ListPersonsInput(display_name="test")

--- a/tests/services/test_search.py
+++ b/tests/services/test_search.py
@@ -12,6 +12,8 @@ from husky_directory.models.search import SearchDirectoryInput
 from husky_directory.services.pws import PersonWebServiceClient
 from husky_directory.services.search import (
     DirectorySearchService,
+)
+from husky_directory.services.translator import (
     ListPersonsOutputTranslator,
     PersonOutputFilter,
 )
@@ -25,7 +27,9 @@ class TestDirectorySearchService:
         self.pws: PersonWebServiceClient = injector.get(PersonWebServiceClient)
 
         self.mock_list_persons = mock.patch.object(self.pws, "list_persons").start()
-        self.mock_get_next = mock.patch.object(self.pws, "get_next").start()
+        self.mock_get_explicit_href = mock.patch.object(
+            self.pws, "get_explicit_href"
+        ).start()
 
         self.set_list_persons_output(
             mock_people.as_search_output(mock_people.published_employee)
@@ -37,7 +41,7 @@ class TestDirectorySearchService:
 
     def set_get_next_output(self, output: ListPersonsOutput):
         self.get_next_output = output
-        self.mock_get_next.return_value = output
+        self.mock_get_explicit_href.return_value = output
 
     def test_search_directory_happy(self):
         request_input = SearchDirectoryInput(name="foo")

--- a/tests/services/test_vcard.py
+++ b/tests/services/test_vcard.py
@@ -1,0 +1,219 @@
+from typing import List, Optional, cast
+from unittest import mock
+
+import pytest
+from injector import Injector
+from werkzeug.exceptions import Forbidden
+from werkzeug.local import LocalProxy
+
+from husky_directory.models.pws import (
+    EmployeeDirectoryListing,
+    EmployeePersonAffiliation,
+    EmployeePosition,
+    PersonAffiliations,
+    PersonOutput,
+    StudentDirectoryListing,
+    StudentPersonAffiliation,
+)
+from husky_directory.models.vcard import VCard, VCardPhone
+from husky_directory.services.pws import PersonWebServiceClient
+from husky_directory.services.vcard import VCardService
+
+
+@pytest.fixture
+def employee(generate_person) -> PersonOutput:
+    positions = [
+        EmployeePosition(
+            department="Snack Eating", title="Chief of Kibble Testing", primary=True
+        ),
+        EmployeePosition(
+            department="Napping", title="Assistant Snuggler", primary=False
+        ),
+    ]
+
+    return generate_person(
+        netid="employee",
+        affiliations=PersonAffiliations.construct(
+            employee=EmployeePersonAffiliation(
+                directory_listing=EmployeeDirectoryListing(
+                    publish_in_directory=True,
+                    phones=["1111111"],
+                    pagers=["1111111"],
+                    mobiles=["1111111"],
+                    faxes=["2222222"],
+                    touch_dials=["3333333"],
+                    emails=["employee@uw.edu"],
+                    positions=positions,
+                )
+            )
+        ),
+    )
+
+
+@pytest.fixture
+def student(generate_person) -> PersonOutput:
+    return generate_person(
+        netid="student",
+        affiliations=PersonAffiliations.construct(
+            student=StudentPersonAffiliation(
+                directory_listing=StudentDirectoryListing(
+                    publish_in_directory=True,
+                    phone="4444444",
+                    email="student@uw.edu",
+                    departments=["Barkochemical Engineering"],
+                    class_level="Goodboi",
+                )
+            )
+        ),
+    )
+
+
+class TestVCardServiceAttributeResolution:
+    @pytest.fixture(autouse=True)
+    def initialize(self, injector: Injector):
+        self.injector = injector
+        self.service = injector.get(VCardService)
+
+    def test_request_is_authenticated(self, client):
+        assert not self.service.request_is_authenticated
+        client.get("/saml/login", follow_redirects=True)
+        assert self.service.request_is_authenticated
+        client.get("/saml/logout", follow_redirects=True)
+        assert not self.service.request_is_authenticated
+
+    def test_set_employee_vcard_attrs(self, employee):
+        vcard = VCard.construct()
+        self.service.set_employee_vcard_attrs(vcard, employee)
+
+        assert vcard.phones == [
+            VCardPhone(
+                types=["pager", "text", "voice"],
+                value="1111111",
+            ),
+            VCardPhone(types=["textphone"], value="3333333"),
+            VCardPhone(types=["fax"], value="2222222"),
+        ]
+
+        assert vcard.email == "employee@uw.edu"
+        assert vcard.departments == ["Snack Eating", "Napping"]
+        assert vcard.titles == ["Chief of Kibble Testing", "Assistant Snuggler"]
+
+    def test_set_student_vcard_attrs(self, student):
+        vcard = VCard.construct()
+        self.service.set_student_vcard_attrs(vcard, student)
+        assert vcard.phones == [VCardPhone(types=["voice"], value="4444444")]
+        assert vcard.email == "student@uw.edu"
+        assert vcard.titles == ["Goodboi"]
+        assert vcard.departments == ["Barkochemical Engineering"]
+
+
+class TestVCardServiceVCardGeneration:
+    @pytest.fixture(autouse=True)
+    def initialize(self, injector: Injector):
+        self.service = injector.get(VCardService)
+        self.pws = injector.get(PersonWebServiceClient)
+        self.session = cast(LocalProxy, {})
+
+        orig_get = injector.get
+
+        def mock_get(cls_):
+            if cls_ == PersonWebServiceClient:
+                return self.pws
+            if cls_ == LocalProxy:
+                return self.session
+            return orig_get(cls_)
+
+        mock.patch.object(injector, "get").start().side_effect = mock_get
+        self.mock_pws_person: Optional[PersonOutput] = None
+
+    def prepare_pws(self):
+        mock_pws_get = mock.patch.object(self.pws, "_get_search_request_output").start()
+        mock_pws_get.return_value = self.mock_pws_person
+
+    def get_vcard_result(self, person: PersonOutput) -> List[str]:
+        self.mock_pws_person = person
+        self.prepare_pws()
+
+        result = self.service.get_vcard("foo")
+        return [line.decode("UTF-8").strip() for line in result.readlines()]
+
+    @property
+    def expected_employee_vcard(self) -> List[str]:
+        return [
+            "BEGIN:VCARD",
+            "N:Lovelace;Ada",
+            "FN:Ada Lovelace",
+            "TITLE:Chief of Kibble Testing",
+            "TITLE:Assistant Snuggler",
+            "ORG:Snack Eating",
+            "ORG:Napping",
+            "EMAIL;type=WORK:employee@uw.edu",
+            'TEL;type="pager,text,voice":1111111',
+            'TEL;type="textphone":3333333',
+            'TEL;type="fax":2222222',
+            "END:VCARD",
+        ]
+
+    def test_employee_vcard(self, employee):
+        self.mock_pws_person = employee
+        self.prepare_pws()
+
+        result = self.get_vcard_result(employee)
+        # Go line by line to make it easier to find issues
+        for i, line in enumerate(result):
+            assert line == self.expected_employee_vcard[i]
+
+    @pytest.mark.parametrize("log_in", (True, False))
+    def test_student_vcard(self, student, client, log_in):
+        expected = [
+            "BEGIN:VCARD",
+            "N:Lovelace;Ada",
+            "FN:Ada Lovelace",
+            "TITLE:Goodboi",
+            "ORG:Barkochemical Engineering",
+            "EMAIL;type=WORK:student@uw.edu",
+            'TEL;type="voice":4444444',
+            "END:VCARD",
+        ]
+
+        if log_in:
+            client.get("/saml/login", follow_redirects=True)
+
+        try:
+            result = self.get_vcard_result(student)
+            for i, line in enumerate(result):
+                assert line == expected[i]
+        except Forbidden:
+            assert not log_in
+
+    @pytest.mark.parametrize("log_in", (True, False))
+    def test_student_employee_vcard(self, student, employee, client, log_in):
+        if log_in:
+            client.get("/saml/login", follow_redirects=True)
+
+        person = student
+        person.affiliations.employee = employee.affiliations.employee
+
+        vcard = self.get_vcard_result(person)
+
+        expected = [
+            "BEGIN:VCARD",
+            "N:Lovelace;Ada",
+            "FN:Ada Lovelace",
+            "TITLE:Goodboi",
+            "TITLE:Chief of Kibble Testing",
+            "TITLE:Assistant Snuggler",
+            "ORG:Barkochemical Engineering",
+            "ORG:Snack Eating",
+            "ORG:Napping",
+            "EMAIL;type=WORK:employee@uw.edu",
+            'TEL;type="pager,text,voice":1111111',
+            'TEL;type="textphone":3333333',
+            'TEL;type="fax":2222222',
+            "END:VCARD",
+        ]
+
+        if not log_in:
+            assert vcard == self.expected_employee_vcard
+        else:
+            assert vcard == expected


### PR DESCRIPTION
Closes EDS-564

See specific commits below for further details.

Broad strokes:

- Adds `/search/person/<token>/vcard` route, where the `/vcard` portion can later be expanded to return `/html` and `/json` results if needed (see also EDS-566).
- Adds "Download vcard" button to the full results template
- When a user clicks the "Download vcard" button, then the vcard is downloaded 🤔

The flask route invokes the `VCardService`, which fetches the person's data from PWS, then translates it into a `VCard` object which, when output as a dict to the jinja2 template engine, generates a vcard based on `vcard.vcf.jinja2`, using the `VCard` model exported dict as the template context.

If that sounded too complicated: It works just like HTML templates, but does for VCF instead.