### PR TITLE
[EDS-524] render department and title in full search results

### DIFF
--- a/husky_directory/templates/full_results.html
+++ b/husky_directory/templates/full_results.html
@@ -17,6 +17,11 @@
                         {% endif %}
                     {% endfor %}
                 </ul>
+                <ul class="multiaddr">
+                    {% for entry in data['departments'] %}
+                    <li>{{entry.title}}, {{entry.department}}</li>
+                    {% endfor %}
+                </ul>
                 <button class="btn btn-primary" name="vcard-{{ loop.index }}">
                     <a href="/search/person/{{ data['href'] }}/vcard"
                        style="color:white;"


### PR DESCRIPTION
- We'll see occasional duplicates in <title, dept> entries for a person, but that's just the data.
- Format is the same as old dir <title>, <dept>
- Closes EDS-524