### PR TITLE
[EDS-568] Actually query for student data when selected (and auth'd)

### DIFF
--- a/husky_directory/templates/result_count.html
+++ b/husky_directory/templates/result_count.html
@@ -2,14 +2,31 @@
     {% if search_result['num_results'] > 0 %}
         {% for scenario in search_result['scenarios'] %}
             {% if scenario['num_results'] > 0 %}
-                {%  set description = scenario['description'] %}
+                {% set description = scenario['description'] %}
+                {#
+                    Because the reponse from the backend may include empty
+                    result sets, we can't just rely on the loop.index to determine
+                    whether or not a comma should precede the count
+                    being emitted. Therefore, we have to do this a special way.
+                    TODO Perhaps the back-end should omit empty
+                         result sets entirely, when returning to render.
+                #}
+                {% set state = {'matched': False} %}
                 {{ description }}:
                 {% for population, query_output in scenario['populations'].items() %}
                     {% set result_count = query_output['num_results'] %}
                     {% if result_count > 0 %}
+                        {% if state.matched %}
+                            , {# Add a comma before all entries after the 1st match #}
+                        {% endif %}
+                        {#
+                            This is a trick to update an existing value that was set
+                            by the template. Otherwise, the value is reset on the next
+                            loop iteration.
+                         #}
+                        {% if state.update({'matched': True}) %}{% endif %}
                         {# when done this needs to look something lik <a href="#f1">1 Faculty/Staff</a> #}
                         {% set anchor_id = 'todo-coming-soon' %}
-                        {{ ', ' if not loop.first else '' }}
                         <a href="#{{ anchor_id}}">
                             {% set population = population|externalize %}
                             {% if result_count == 1 %}


### PR DESCRIPTION
Fixes EDS-568 🐞

Since the PWS search is intersectional, we can't search both for students and employees in a single query (that only returns 'student employees'). This change adds logic to the QueryGenerator to emit student population queries if the request input dictates students should be included, and if the request is authenticated.