### PR TITLE
[EDS-570] Exports box_number to front-end

### DIFF
--- a/husky_directory/services/translator.py
+++ b/husky_directory/services/translator.py
@@ -180,6 +180,7 @@ class ListPersonsOutputTranslator:
                 # it's already set.
                 if employee.directory_listing.emails:
                     result.email = employee.directory_listing.emails[0]
+                result.box_number = employee.mail_stop
                 result.departments.extend(
                     UWDepartmentRole.from_orm(position)
                     for position in employee.directory_listing.positions

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,16 +90,16 @@ def mock_people(generate_person):
         published_employee = generate_person(
             affiliations=PersonAffiliations(
                 employee=EmployeePersonAffiliation(
+                    mail_stop="351234",
                     directory_listing=EmployeeDirectoryListing(
                         publish_in_directory=True,
                         positions=[
                             EmployeePosition(
                                 department="Aeronautics & Astronautics",
                                 title="Senior Orbital Inclinator",
-                                primary=True,
                             )
                         ],
-                    )
+                    ),
                 )
             )
         )

--- a/tests/services/test_search.py
+++ b/tests/services/test_search.py
@@ -11,7 +11,7 @@ from husky_directory.models.pws import (
     ListPersonsInput,
     ListPersonsOutput,
 )
-from husky_directory.models.search import SearchDirectoryInput
+from husky_directory.models.search import Person, SearchDirectoryInput
 from husky_directory.services.pws import PersonWebServiceClient
 from husky_directory.services.search import (
     DirectorySearchService,
@@ -185,8 +185,17 @@ class TestDirectorySearchService:
             name="whatever", population=PopulationType.employees
         )
         output = self.client.search_directory(request_input)
-        output_person = output.scenarios[0].populations["employees"].people[0]
+        output_person: Person = output.scenarios[0].populations["employees"].people[0]
         assert not output_person.departments
+
+    def test_output_includes_box_number(self):
+        person = self.mock_people.published_employee
+        self.list_persons_output.persons = [person]
+        output = self.client.search_directory(
+            SearchDirectoryInput(name="*blah", population=PopulationType.employees)
+        )
+        output_person: Person = output.scenarios[0].populations["employees"].people[0]
+        assert output_person.box_number == "351234"
 
 
 class TestPersonOutputTranslator:


### PR DESCRIPTION
This one is pretty straightforward. Enables the box_number output to the frontend for employee `Person`s and adds a test to ensure its inclusion.

Search for any employee at the JSON endpoint to verify, e.g.: `http://localhost:8000/search?population=employees&name=cauce`

```
          "people": [
            {
              "boxNumber": "35xxxx", // it's probably fine to include the real one but meh 
              "departments": [
                {
                  "department": "University of Washington", 
                  "title": "President"
                }, 
```