### PR TITLE
[EDS-575] create blank table cell in description row

### DIFF
--- a/husky_directory/templates/summary_results_table/scenario_population_block.html
+++ b/husky_directory/templates/summary_results_table/scenario_population_block.html
@@ -10,6 +10,7 @@ and then 1 or more rows of results. #}
             </h3>
         </div>
     </td>
+    <td>&nbsp;</td>
 </tr>
 
 {# data: models.search.Person #}


### PR DESCRIPTION
- parity with old directory
- adds blank table cell in description row of summary results for alignment/border.
- closes EDS-575