### PR TITLE
[EDS-572] Changes vcard phone types back to those defined in whitepages-ui.

### DIFF
--- a/husky_directory/blueprints/saml.py
+++ b/husky_directory/blueprints/saml.py
@@ -1,6 +1,5 @@
 import getpass
 from logging import Logger
-from urllib.parse import urljoin
 
 import uw_saml2
 from flask import Blueprint, Request, redirect

--- a/husky_directory/blueprints/saml.py
+++ b/husky_directory/blueprints/saml.py
@@ -30,12 +30,6 @@ class SAMLBlueprint(Blueprint):
         session["uwnetid"] = attributes["uwnetid"]
         self.logger.info(f"Signed in user {session['uwnetid']}")
         relay_state = request.form.get("RelayState")
-
-        if relay_state:
-            if not relay_state.startswith("http"):
-                if not relay_state.startswith("/"):
-                    relay_state = f"/{relay_state}"
-                relay_state = urljoin(request.url_root, relay_state)
         return redirect(relay_state or "/")
 
     def login(self, request: Request, session: LocalProxy):

--- a/husky_directory/models/search.py
+++ b/husky_directory/models/search.py
@@ -5,13 +5,18 @@ from __future__ import annotations
 
 import base64
 import re
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, TYPE_CHECKING
 
 from pydantic import Field, PydanticValueError, validator
 
 from husky_directory.models.base import DirectoryBaseModel
 from husky_directory.models.common import UWDepartmentRole
 from husky_directory.models.enum import PopulationType, ResultDetail
+
+# There is no direct dependency on the model here, we only need it for type checking;
+# this protects us from accidentally creating a cyclic dependency between the modules.
+if TYPE_CHECKING:
+    pass
 
 
 class BoxNumberValueError(PydanticValueError):
@@ -139,8 +144,9 @@ class SearchDirectoryInput(DirectoryBaseModel):
 
 
 class PhoneContactMethods(DirectoryBaseModel):
-    # These aliases are for humans, instead of for computers, so use
-    # human conventions for the front end to display.
+    class Config(DirectoryBaseModel.Config):
+        orm_mode = True
+
     phones: List[str] = []
     faxes: List[str] = []
     voice_mails: List[str] = []

--- a/husky_directory/models/vcard.py
+++ b/husky_directory/models/vcard.py
@@ -5,12 +5,13 @@ from husky_directory.models.base import DirectoryBaseModel
 
 
 class VCardPhoneType(Enum):
-    text = "text"
-    voice = "voice"
+    work = "work"
+    home = "home"
     fax = "fax"
-    cell = "cell"
     pager = "pager"
-    textphone = "textphone"  # TDD
+    cell = "cell"
+    tdd = "TTY-TDD"
+    message = "MSG"
 
 
 class VCardPhone(DirectoryBaseModel):

--- a/husky_directory/services/translator.py
+++ b/husky_directory/services/translator.py
@@ -111,27 +111,19 @@ class ListPersonsOutputTranslator:
 
         return True
 
+    @staticmethod
     def _resolve_phones(
-        self,
         employee_affiliation: Optional[EmployeePersonAffiliation],
         student_affiliation: Optional[StudentPersonAffiliation],
     ) -> PhoneContactMethods:
-        model = PhoneContactMethods()
         if employee_affiliation:
-            model = model.copy(
-                update=employee_affiliation.directory_listing.dict(
-                    include={
-                        "phones",
-                        "pagers",
-                        "voice_mails",
-                        "touch_dials",
-                        "faxes",
-                        "mobiles",
-                    },
-                )
-            )
+            model = PhoneContactMethods.from_orm(employee_affiliation.directory_listing)
+        else:
+            model = PhoneContactMethods()
+
         if student_affiliation:
             model.phones.append(student_affiliation.directory_listing.phone)
+
         return model
 
     def translate_scenario(

--- a/husky_directory/templates/vcard.vcf.jinja2
+++ b/husky_directory/templates/vcard.vcf.jinja2
@@ -17,8 +17,8 @@ TITLE:{{ title }}
 ORG:University of Washington;{{ dept }}
 {% endfor %}
 {% if not email is blank %}
-{# EMAIL;type=INTERNET;type=WORK:dawg@uw.edu #}
-EMAIL;type=WORK:{{ email }}
+{# EMAIL;type=INTERNET,type=WORK:dawg@uw.edu #}
+EMAIL;type=INTERNET,type=WORK:{{ email }}
 {% endif %}
 {% for phone in phones %}
 {# TEL;type="pager,voice":5558675309 #}

--- a/tests/services/test_vcard.py
+++ b/tests/services/test_vcard.py
@@ -24,12 +24,8 @@ from husky_directory.services.vcard import VCardService
 @pytest.fixture
 def employee(generate_person) -> PersonOutput:
     positions = [
-        EmployeePosition(
-            department="Snack Eating", title="Chief of Kibble Testing", primary=True
-        ),
-        EmployeePosition(
-            department="Napping", title="Assistant Snuggler", primary=False
-        ),
+        EmployeePosition(department="Snack Eating", title="Chief of Kibble Testing"),
+        EmployeePosition(department="Napping", title="Assistant Snuggler"),
     ]
 
     return generate_person(
@@ -88,10 +84,10 @@ class TestVCardServiceAttributeResolution:
 
         assert vcard.phones == [
             VCardPhone(
-                types=["pager", "text", "voice"],
+                types=["cell", "pager", "work"],
                 value="1111111",
             ),
-            VCardPhone(types=["textphone"], value="3333333"),
+            VCardPhone(types=["TTY-TDD"], value="3333333"),
             VCardPhone(types=["fax"], value="2222222"),
         ]
 
@@ -102,7 +98,7 @@ class TestVCardServiceAttributeResolution:
     def test_set_student_vcard_attrs(self, student):
         vcard = VCard.construct()
         self.service.set_student_vcard_attrs(vcard, student)
-        assert vcard.phones == [VCardPhone(types=["voice"], value="4444444")]
+        assert vcard.phones == [VCardPhone(types=["home"], value="4444444")]
         assert vcard.email == "student@uw.edu"
         assert vcard.titles == ["Goodboi"]
         assert vcard.departments == ["Barkochemical Engineering"]
@@ -142,9 +138,9 @@ class TestVCardServiceVCardGeneration:
             "TITLE:Assistant Snuggler",
             "ORG:University of Washington;Snack Eating",
             "ORG:University of Washington;Napping",
-            "EMAIL;type=WORK:employee@uw.edu",
-            'TEL;type="pager,text,voice":1111111',
-            'TEL;type="textphone":3333333',
+            "EMAIL;type=INTERNET,type=WORK:employee@uw.edu",
+            'TEL;type="cell,pager,work":1111111',
+            'TEL;type="TTY-TDD":3333333',
             'TEL;type="fax":2222222',
             "END:VCARD",
         ]
@@ -245,8 +241,8 @@ class TestVCardServiceVCardGeneration:
             "FN:Ada Lovelace",
             "TITLE:Goodboi",
             "ORG:University of Washington;Barkochemical Engineering",
-            "EMAIL;type=WORK:student@uw.edu",
-            'TEL;type="voice":4444444',
+            "EMAIL;type=INTERNET,type=WORK:student@uw.edu",
+            'TEL;type="home":4444444',
             "END:VCARD",
         ]
 
@@ -280,9 +276,10 @@ class TestVCardServiceVCardGeneration:
             "ORG:University of Washington;Barkochemical Engineering",
             "ORG:University of Washington;Snack Eating",
             "ORG:University of Washington;Napping",
-            "EMAIL;type=WORK:employee@uw.edu",
-            'TEL;type="pager,text,voice":1111111',
-            'TEL;type="textphone":3333333',
+            "EMAIL;type=INTERNET,type=WORK:employee@uw.edu",
+            'TEL;type="home":4444444',
+            'TEL;type="cell,pager,work":1111111',
+            'TEL;type="TTY-TDD":3333333',
             'TEL;type="fax":2222222',
             "END:VCARD",
         ]


### PR DESCRIPTION
My belief that these codes were against spec was an overly strict interpretation was incorrect, and JP found the documentation to prove it. 

This makes the phone types have [parity with the existing directory](https://github.com/UWIT-IAM/whitepages-ui/blob/master/vcui.c#L372-L406). Tried with our usual folks, plus some random students here and there. 

Closes EDS-572