### PR TITLE
[EDS-576] ensure all human names are normalized on import from PWS

### DIFF
--- a/husky_directory/models/pws.py
+++ b/husky_directory/models/pws.py
@@ -7,6 +7,7 @@ These are not 1:1 models of that API; only fields we care about are declared her
 
 from typing import Any, Dict, List, Optional
 
+from inflection import titleize
 from pydantic import BaseModel, Extra, Field, validator
 
 from .common import UWDepartmentRole
@@ -118,7 +119,6 @@ class EmployeePosition(PWSBaseModel, UWDepartmentRole):
 
 
 class EmployeeDirectoryListing(PWSBaseModel):
-    name: Optional[str]
     publish_in_directory: bool
     phones: List[str] = []
     emails: List[str] = Field(default=[], alias="EmailAddresses")
@@ -131,7 +131,6 @@ class EmployeeDirectoryListing(PWSBaseModel):
 
 
 class StudentDirectoryListing(PWSBaseModel):
-    name: Optional[str]
     publish_in_directory: bool
     phone: Optional[str]
     email: Optional[str]
@@ -166,6 +165,20 @@ class NamedIdentity(PWSBaseModel):
     preferred_first_name: Optional[str]
     preferred_middle_name: Optional[str]
     preferred_last_name: Optional[str]
+
+    @validator(
+        "display_name",
+        "registered_name",
+        "registered_first_middle_name",
+        "registered_surname",
+        "preferred_first_name",
+        "preferred_middle_name",
+        "preferred_last_name",
+    )
+    def humanize_name_field(cls, value: Optional[str]) -> Optional[str]:
+        if value:
+            return titleize(value)
+        return value
 
 
 class PersonOutput(NamedIdentity):

--- a/tests/models/test_pws_models.py
+++ b/tests/models/test_pws_models.py
@@ -1,4 +1,27 @@
-from husky_directory.models.pws import PersonOutput
+from husky_directory.models.pws import NamedIdentity, PersonOutput
+
+
+def test_name_formatting():
+    identity = NamedIdentity(
+        display_name="ALOE VERA",
+        registered_name="aloe VERA",
+        registered_first_middle_name="Aloe A. Vera",
+        registered_surname="VERA",
+        preferred_first_name="Aloe",
+        preferred_middle_name="A.",
+        preferred_last_name="VERA",
+    )
+
+    expected = {
+        "display_name": "Aloe Vera",
+        "registered_name": "Aloe Vera",
+        "registered_first_middle_name": "Aloe A. Vera",
+        "registered_surname": "Vera",
+        "preferred_first_name": "Aloe",
+        "preferred_middle_name": "A.",
+        "preferred_last_name": "Vera",
+    }
+    assert identity.dict() == expected
 
 
 def test_person_output_href():


### PR DESCRIPTION
Closes EDS-576

This nips the problem in the bud at the source, and converts all name fields on import, so oddly cased names will never be inside our system at all.

For clarity, also removes unused additional 'name' fields in the affiliation listings.