### PR TITLE
[EDS-578, EDS-571] Generate anchor references and headings

### DIFF
--- a/husky_directory/app.py
+++ b/husky_directory/app.py
@@ -85,8 +85,22 @@ class AppInjectorModule(Module):
             return inflection.titleize(text)
 
         @app.template_filter()
-        def singularize(text):
+        def singularize(text: str):
+            """
+            Takes something plural and makes it singular.
+            Use: {{ "parrots"|singularize }}
+            """
             return inflection.singularize(text)
+
+        @app.template_filter()
+        def linkify(text: str):
+            """
+            Replaces all non alphanum characters with '-' and lowercases
+            everything.
+                "foo: bar baz st. claire" => "foo-bar-baz-st-claire"
+            use: {{ "Foo Bar Baz St. Claire"|linkify }}
+            """
+            return inflection.parameterize(text)
 
         @app.template_filter()
         def externalize(text):

--- a/husky_directory/app_config.py
+++ b/husky_directory/app_config.py
@@ -199,7 +199,7 @@ class ApplicationConfig(FlaskConfigurationSettings):
     def validate_redis_settings(
         cls, redis_settings: Optional[RedisSettings], values: Dict
     ) -> Optional[RedisSettings]:
-        """Ensurues that, if redis is the selected session type, a redis setting object is created if it is not
+        """Ensures that, if redis is the selected session type, a redis setting object is created if it is not
         already passed in."""
         if (
             cast(SessionSettings, values.get("session_settings")).session_type

--- a/husky_directory/templates/full_results.html
+++ b/husky_directory/templates/full_results.html
@@ -2,35 +2,42 @@
 {% for scenario in search_result["scenarios"]%}
     {% if scenario['num_results'] > 0 %}
         <p>
-        <h4>{{scenario['description']}}</h4>
-        {# population: models.search.DirectoryQueryPopulationOutput #}
+        {# population: str
+         # results: models.search.DirectoryQueryPopulationOutput
+        #}
         {% for population, results in scenario['populations'].items() %}
-            {% for data in results['people'] %}
-                <h3>{{ data['name'] }}</h3>
-                <ul class="dir-listing">
-                    <li>{{ data['email'] }}</li>
-                    {% for contact_method, numbers in
-                       data['phone_contacts'].items() %}
-                        {% if numbers|length %}
-                            <li>{{ contact_method|singularize|titleize }}:
-                                {{ numbers|join(', ') }}</li>
+            {% if results['num_results'] > 0 %}
+                <h3 class='scenario-anchor'
+                    id="{{ population ~ '-' ~ scenario['description']|linkify }}">
+                    {{ population|externalize|titleize}}: {{ scenario['description']}}
+                </h3>
+                {% for data in results['people'] %}
+                    <h4>{{ data['name'] }}</h4>
+                    <ul class="dir-listing">
+                        <li>{{ data['email'] }}</li>
+                        {% for contact_method, numbers in
+                           data['phone_contacts'].items() %}
+                            {% if numbers|length %}
+                                <li>{{ contact_method|singularize|titleize }}:
+                                    {{ numbers|join(', ') }}</li>
+                            {% endif %}
+                        {% endfor %}
+                        {% if data['box_number'] %}
+                            <li class="dir-boxstuff">Box {{ data['box_number'] }}</li>
                         {% endif %}
-                    {% endfor %}
-                    {% if data['box_number'] %}
-                        <li class="dir-boxstuff">Box {{ data['box_number'] }}</li>
-                    {% endif %}
-                </ul>
-                <ul class="multiaddr">
-                    {% for entry in data['departments'] %}
-                        <li>{{ entry.title }}, {{ entry.department }}</li>
-                    {% endfor %}
-                </ul>
-                <button class="btn btn-primary" name="vcard-{{ loop.index }}">
-                    <a href="/search/person/{{ data['href'] }}/vcard"
-                       style="color:white;"
-                       download="{{ data['name'] }}.vcf">Download vcard</a>
-                </button>
-            {% endfor %}
+                    </ul>
+                    <ul class="multiaddr">
+                        {% for entry in data['departments'] %}
+                            <li>{{ entry.title }}, {{ entry.department }}</li>
+                        {% endfor %}
+                    </ul>
+                    <button class="btn btn-primary" name="vcard-{{ loop.index }}">
+                        <a href="/search/person/{{ data['href'] }}/vcard"
+                           style="color:white;"
+                           download="{{ data['name'] }}.vcf">Download vcard</a>
+                    </button>
+                {% endfor %}
+            {% endif %}
         {% endfor %}
         </p>
     {% endif %}

--- a/husky_directory/templates/result_count.html
+++ b/husky_directory/templates/result_count.html
@@ -26,8 +26,8 @@
                          #}
                         {% if state.update({'matched': True}) %}{% endif %}
                         {# when done this needs to look something lik <a href="#f1">1 Faculty/Staff</a> #}
-                        {% set anchor_id = 'todo-coming-soon' %}
-                        <a href="#{{ anchor_id}}">
+                        {% set anchor_id = population ~ '-' ~ description|linkify %}
+                        <a class='scenario-anchor-reference' href="#{{ anchor_id}}">
                             {% set population = population|externalize %}
                             {% if result_count == 1 %}
                                 {% set population = population|singularize %}
@@ -42,4 +42,3 @@
         <br>
     {% endif %}
 </div>
-

--- a/husky_directory/templates/summary_results_table/scenario_population_block.html
+++ b/husky_directory/templates/summary_results_table/scenario_population_block.html
@@ -3,8 +3,10 @@ and then 1 or more rows of results. #}
 <tr>
     <td colspan="3">
         <div class="rcdescr">
-            {% set anchor_id = 'todo-coming-soon' %}
-            <h3><a id="{{ anchor_id }}" name="{{ anchor_id }}"></a>
+            {% set scenario_desc = scenario['description'] %}
+            {% set anchor_id = population_name ~ '-' ~ scenario_desc|linkify %}
+            <h3 class='scenario-anchor-reference'
+                id="{{ anchor_id }}">
                 {{ population_name|externalize|titleize }}:
                 {{ scenario['description'] }}
             </h3>

--- a/tests/blueprints/test_search_blueprint.py
+++ b/tests/blueprints/test_search_blueprint.py
@@ -71,7 +71,11 @@ class TestSearchBlueprint(BlueprintSearchTestBase):
         )
         profile = self.mock_people.contactable_person
         with self.html_validator.validate_response(response):
-            self.html_validator.assert_has_tag_with_text("h3", profile.display_name)
+            self.html_validator.assert_has_tag_with_text("h4", profile.display_name)
+            self.html_validator.assert_has_scenario_anchor("employees-name-matches-foo")
+            self.html_validator.assert_not_has_scenario_anchor(
+                "students-name-matches-foo"
+            )
             with self.html_validator.scope("ul", class_="dir-listing"):
                 self.html_validator.assert_has_tag_with_text(
                     "li", profile.affiliations.employee.directory_listing.emails[0]
@@ -87,6 +91,12 @@ class TestSearchBlueprint(BlueprintSearchTestBase):
         self.mock_list_persons.return_value = self.mock_people.as_search_output()
         response = self.flask_client.post("/search", data={"query": "foo"})
         with self.html_validator.validate_response(response) as html:
+            self.html_validator.assert_not_has_scenario_anchor(
+                "employees-name-matches-foo"
+            )
+            self.html_validator.assert_not_has_scenario_anchor(
+                "students-name-matches-foo"
+            )
             assert not html.find("table", summary="results")
             assert html.find(string=re.compile("No matches for"))
             self.html_validator.assert_has_tag_with_text("b", 'Name is "foo"')
@@ -112,11 +122,15 @@ class TestSearchBlueprint(BlueprintSearchTestBase):
                 data={
                     "query": "foo",
                     "length": "full",
-                    "population": "students",
+                    "population": "all",
                 },
             )
         ) as html:
             assert not html.find_all("li", class_="dir-boxstuff")
+            self.html_validator.assert_has_scenario_anchor("students-name-matches-foo")
+            self.html_validator.assert_not_has_scenario_anchor(
+                "employees-name-matches-foo"
+            )
             with self.html_validator.scope("div", class_="usebar"):
                 self.html_validator.assert_has_tag_with_text("button", "Download vcard")
 


### PR DESCRIPTION
Closes EDS-578 and EDS-571

- Adds anchor headings to `full_results.html`
- Ensure a canonical heading hierarchy on `full_results.html` (change the scenario header to h3, and the person's name to h4). If we really need or want the text size to be at parity, we can change the CSS to reflect this. This way the page is structured correctly.
- Adds anchor references to `result_count.html` links
- Adds anchors to scenario headings in `scenario_population_block.html`, part of the the summary results table.
- Adds a positive and a negative test for the for scenario links and references