### PR TITLE
Finishes redis cache configuration

### DIFF
--- a/.github/actions/calculate-base-fingerprint/action.yml
+++ b/.github/actions/calculate-base-fingerprint/action.yml
@@ -1,8 +1,0 @@
-name: Calculate base image fingerprint
-runs:
-  using: 'composite'
-  shell: bash
-  run: |
-    FINGERPRINT=${{ hashFiles('poetry.lock', 'docker/husky-directory-base.dockerfile') }}
-    echo ::set-output name=fingerprint::$FINGERPRINT
-    echo "FINGERPRINT=$FINGERPRINT" >> $GITHUB_ENV

--- a/.github/actions/calculate-base-fingerprint/action.yml
+++ b/.github/actions/calculate-base-fingerprint/action.yml
@@ -1,0 +1,8 @@
+name: Calculate base image fingerprint
+runs:
+  using: 'composite'
+  shell: bash
+  run: |
+    FINGERPRINT=${{ hashFiles('poetry.lock', 'docker/husky-directory-base.dockerfile') }}
+    echo ::set-output name=fingerprint::$FINGERPRINT
+    echo "FINGERPRINT=$FINGERPRINT" >> $GITHUB_ENV

--- a/.github/scripts/pull-or-build-base.sh
+++ b/.github/scripts/pull-or-build-base.sh
@@ -12,6 +12,7 @@ if [[ "${PULL_FAILED}" = "1" ]]
 then
   echo "${BASE_TAG_NAME} pull failed; building it, instead."
   set -ex
-  docker build -f docker/husky-directory-base.dockerfile -t ${BASE_TAG_NAME} .
+  docker build -f docker/husky-directory-base.dockerfile \
+    --build-arg FINGERPRINT -t ${BASE_TAG_NAME} .
   set +x
 fi

--- a/.github/scripts/set-post-push-workflow-vars.sh
+++ b/.github/scripts/set-post-push-workflow-vars.sh
@@ -3,6 +3,10 @@
 # REPO_HOST -- e.g., gcr.io
 # REPO_PROJECT -- e.g., uwit-mci-iam
 # APP_NAME -- e.g., husky-directory
+# DEPLOY_TARGET -- e.g., 'dev'
+# BASE_FINGERPRINT -- The SHA256 fingerprint of the poetry lock file and the
+#                            base image dockerfile,
+#                            calculated using Actions hashFiles function.
 # Other variables are depended on but set by github:
 # GITHUB_SHA -- the commit reference of the change being built
 #     Note that this will not be deterministic, nor will it match the repository
@@ -12,7 +16,9 @@ set -ex
 
 #!/usr/bin/env bash
 
-COMMIT_PREFIX=$(echo $GITHUB_SHA | cut -c 1-10)
+DEPLOY_TARGET=${DEPLOY_TARGET:-dev}
+
+COMMIT_PREFIX=${GITHUB_SHA:0:10}
 APP_BUILD_LABEL=commit-${COMMIT_PREFIX}
 echo ::set-output name=app_build_version::${APP_BUILD_LABEL}
 
@@ -22,16 +28,15 @@ echo ::set-output name=app_repo::${APP_REPO}
 APP_BUILD_TAG=${APP_REPO}:commit-${COMMIT_PREFIX}
 echo ::set-output name=app_build_tag::${APP_BUILD_TAG}
 
-APP_HEAD_TAG=${APP_REPO}:deploy-dev.${COMMIT_PREFIX}
+APP_HEAD_TAG=${APP_REPO}:deploy-${DEPLOY_TARGET}.${COMMIT_PREFIX}
 echo ::set-output name=app_head_tag::${APP_HEAD_TAG}
 
-
-echo ::set-output name=base_build_version::${POETRY_LOCK_MD5}
+echo ::set-output name=base_build_version::${BASE_FINGERPRINT}
 
 BASE_REPO=${REPO_HOST}/${REPO_PROJECT}/${APP_NAME}-base
 echo ::set-output name=base_repo::${BASE_REPO}
 
-BASE_BUILD_TAG=${BASE_REPO}:${POETRY_LOCK_MD5}
+BASE_BUILD_TAG=${BASE_REPO}:${BASE_FINGERPRINT}
 echo ::set-output name=base_build_tag::${BASE_BUILD_TAG}
 
 BASE_HEAD_TAG=${BASE_REPO}:latest

--- a/.github/scripts/set-post-push-workflow-vars.sh
+++ b/.github/scripts/set-post-push-workflow-vars.sh
@@ -1,7 +1,7 @@
 # Sets up variables that are used in the rest of the workflow.
 # Expects the following variables to be set by the workflow yml:
 # REPO_HOST -- e.g., gcr.io
-# REPO_PROJECT -- e.g., uwit-mci-iam
+# REPO_PROJECT
 # APP_NAME -- e.g., husky-directory
 # DEPLOY_TARGET -- e.g., 'dev'
 # BASE_FINGERPRINT -- The SHA256 fingerprint of the poetry lock file and the
@@ -13,6 +13,8 @@
 #     history after it is merged. That's a Github problem.
 
 set -ex
+
+test -n "$BASE_FINGERPRINT"
 
 #!/usr/bin/env bash
 

--- a/.github/workflows/post-push.yml
+++ b/.github/workflows/post-push.yml
@@ -20,7 +20,7 @@ on:
 env:
   APP_NAME: husky-directory
   REPO_HOST: gcr.io
-  REPO_PROJECT: ${{ secrets.IAM_GCR_REPO }}
+  REPO_PROJECT: uwit-mci-iam
   GCR_TOKEN: ${{ secrets.GCR_TOKEN }}
 jobs:
   # This job simply builds and outputs some variables used in other contexts
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - uses: ./.github/actions/calculate-base-fingerprint
-        id: calculate-fingerprint
       - env:
-          BASE_FINGERPRINT=${{ steps.calculate-fingerprint.outputs.fingerprint }}
+          # Despite my best efforts, this cannot currently be
+          # factored into a common action. See # https://github.com/actions/runner/issues/991
+          BASE_FINGERPRINT: ${{ hashFiles('poetry.lock', 'docker/husky-directory-base.dockerfile') }}
         name: Set up build variables
         id: set_vars
         run: ./.github/scripts/set-post-push-workflow-vars.sh
@@ -45,7 +45,6 @@ jobs:
       base_build_version: ${{ steps.set_vars.outputs.base_build_version }}
       base_build_tag: ${{ steps.set_vars.outputs.base_build_tag }}
       base_head_tag: ${{ steps.set_vars.outputs.base_head_tag }}
-      base_build_fingerprint: ${{ steps.calculate-fingerprint.outputs.fingerprint }}
 
   # This job is responsible for building an image and uploading it to our repository. This image can later be
   # tested, deployed, and/or have other tags applied.
@@ -143,7 +142,7 @@ jobs:
         # Once accepted into the main branch, the base image is tagged as
         # `dev`; future builds will use `latest` requirements.
         env:
-          BUILD_TAG: ${{ needs.calculate-fingerprint.outputs.fingerprint }}
+          BUILD_TAG: ${{ needs.configure-image.outputs.base_build_tag }}
           HEAD_TAG: dev
         run: |
           docker pull ${BUILD_TAG}

--- a/.github/workflows/post-push.yml
+++ b/.github/workflows/post-push.yml
@@ -20,7 +20,7 @@ on:
 env:
   APP_NAME: husky-directory
   REPO_HOST: gcr.io
-  REPO_PROJECT: uwit-mci-iam
+  REPO_PROJECT: ${{ secrets.IAM_GCR_REPO }}
   GCR_TOKEN: ${{ secrets.GCR_TOKEN }}
 jobs:
   # This job simply builds and outputs some variables used in other contexts
@@ -28,13 +28,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - # Creates a full image name from the above tag and environment variables
-        # It will be something like: uwitiam/husky-directory:commit-abcde12345
+      - uses: ./.github/actions/calculate-base-fingerprint
+        id: calculate-fingerprint
+      - env:
+          BASE_FINGERPRINT=${{ steps.calculate-fingerprint.outputs.fingerprint }}
         name: Set up build variables
         id: set_vars
-        env:
-          POETRY_LOCK_MD5: ${{ hashFiles('pyproject.toml', 'docker/husky-directory-base.dockerfile') }}
-        run: ./.github/scripts/set-workflow-vars.sh
+        run: ./.github/scripts/set-post-push-workflow-vars.sh
     outputs:
       # These are all set by the set-workflow-vars.sh script.
       app_repo: ${{ steps.set_vars.outputs.app_repo }}
@@ -45,6 +45,7 @@ jobs:
       base_build_version: ${{ steps.set_vars.outputs.base_build_version }}
       base_build_tag: ${{ steps.set_vars.outputs.base_build_tag }}
       base_head_tag: ${{ steps.set_vars.outputs.base_head_tag }}
+      base_build_fingerprint: ${{ steps.calculate-fingerprint.outputs.fingerprint }}
 
   # This job is responsible for building an image and uploading it to our repository. This image can later be
   # tested, deployed, and/or have other tags applied.
@@ -129,7 +130,7 @@ jobs:
 
   # Only run this workflow when pushing to main, after all above checks have
   # succeeded.
-  promote-deployment:
+  promote-deployment-to-dev:
     needs: [configure-image, validate-image-quality, build-and-push-image]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
@@ -140,10 +141,10 @@ jobs:
       # them DRY.
       - name: Update base image to latest
         # Once accepted into the main branch, the base image is tagged as
-        # `latest`; future builds will use `latest` requirements.
+        # `dev`; future builds will use `latest` requirements.
         env:
-          BUILD_TAG: ${{ needs.configure-image.outputs.base_build_tag }}
-          HEAD_TAG: ${{ needs.configure-image.outputs.base_head_tag }}
+          BUILD_TAG: ${{ needs.calculate-fingerprint.outputs.fingerprint }}
+          HEAD_TAG: dev
         run: |
           docker pull ${BUILD_TAG}
           docker tag ${BUILD_TAG} ${HEAD_TAG}

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -20,8 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
-      - id: calculate-fingerprint
-        uses: ./.github/actions/calculate-base-fingerprint
       - with:
           project_id: ${{ secrets.IAM_GCR_REPO }}
           service_account_key: ${{ secrets.GCR_TOKEN }}
@@ -68,7 +66,9 @@ jobs:
         uses: UWIT-IAM/actions/update-slack-workflow-canvas@release
       - name: Rebuild husky-directory-base
         env:
-          FINGERPRINT=${{ steps.calculate-fingerprint.outputs.fingerprint }}
+          # Despite my best efforts, this cannot currently be
+          # factored into a common action. See # https://github.com/actions/runner/issues/991
+          FINGERPRINT: ${{ hashFiles('poetry.lock', 'docker/husky-directory-base.dockerfile') }}
         run: |
           gcloud auth configure-docker
           docker build --build-arg FINGERPRINT docker/husky-directory-base .dockerfile . -t base

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
+      - id: calculate-fingerprint
+        uses: ./.github/actions/calculate-base-fingerprint
       - with:
           project_id: ${{ secrets.IAM_GCR_REPO }}
           service_account_key: ${{ secrets.GCR_TOKEN }}
@@ -65,9 +67,11 @@ jobs:
           step-status: in progress
         uses: UWIT-IAM/actions/update-slack-workflow-canvas@release
       - name: Rebuild husky-directory-base
+        env:
+          FINGERPRINT=${{ steps.calculate-fingerprint.outputs.fingerprint }}
         run: |
           gcloud auth configure-docker
-          docker build -f docker/husky-directory-base.dockerfile . -t base
+          docker build --build-arg FINGERPRINT docker/husky-directory-base .dockerfile . -t base
       - with:
           command: update-workflow
           step-id: rebuild-base-image

--- a/docker/development-server.dockerfile
+++ b/docker/development-server.dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_VERSION=latest
+ARG BASE_VERSION=edge
 FROM gcr.io/uwit-mci-iam/husky-directory-base:${BASE_VERSION} as poetry-base
 ARG ENV_FILE=husky_directory/settings/base.dotenv
 WORKDIR /scripts

--- a/docker/docker-compose.app-with-redis.yaml
+++ b/docker/docker-compose.app-with-redis.yaml
@@ -1,0 +1,22 @@
+# If you want to run a local instance with redis, you can use this directly, but
+# it's probably better to use:
+#     ./scripts/run-development-server.sh --with-redis
+#
+
+services:
+  app:
+    env_file:
+      - ${PWD}/husky_directory/settings/compose-with-redis.dotenv
+    environment:
+      UWCA_MOUNT_PATH: "${UWCA_CERT_PATH}"
+      REDIS_NAMESPACE: directory
+    image: ${APP_IMAGE}
+    ports: ["8000:8000"]
+    volumes:
+      - ${UWCA_CERT_PATH}:/app/certificates:ro
+      - ${PWD}/husky_directory:/app/husky_directory
+  redis:
+    image: redis:latest
+    command: redis-server --requirepass supersecret
+    ports:
+      - "6379:6379"

--- a/docker/husky-directory-base.dockerfile
+++ b/docker/husky-directory-base.dockerfile
@@ -1,6 +1,8 @@
 ARG BASE_VERSION=latest
+ARG FINGERPRINT=""
 FROM ghcr.io/uwit-iam/uw-saml-poetry:${BASE_VERSION} as poetry-base
 WORKDIR /app
 COPY poetry.lock pyproject.toml ./
-ENV PATH="$POETRY_HOME/bin:$PATH"
+ENV PATH="$POETRY_HOME/bin:$PATH" \
+    UW_HUSKY_DIRECTORY_BASE_FINGERPRINT=${FINGERPRINT}
 RUN poetry install

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -12,15 +12,25 @@ These build images, when attached to a pull request, will also be tagged with
 reflect the latest build of the pull request; previous builds will still be 
 accessible by their commit tag above.
 
-Images tagged with `deploy-dev.commit-X` are images that were tagged for deployment 
+Images tagged with `deploy-dev.X` (where X is the first 9 chars of the commit SHA) 
+are images that were tagged for deployment 
 to our [development environment](https://github.com/uwit-iam/gcp-k8/tree/master/dev/uw-directory).
 
-Images tagged with a [sem ver](https://www.semver.org) `X.Y.Z` will be automatically 
-deployed to our eval environment. (Which is not currently configured.)
+Images tagged with a `deploy-eval.X` (where X is the first 9 chars of the commit SHA)
+automatically deployed to our eval environment. 
+Currently this requires a manual promotion that can be done like so:
 
-Images tagged with both `prod` and a released sem ver tag (i.e., when one of those 
-sem ver tags is also tagged with `prod`), then it will also be deployed to prod. 
-(The prod environment is not currently configured.)
+```
+# Get the currently deployed build id in dev
+BUILD_ID=$(curl -k https://uw-directory.iamdev.s.uw.edu/health | jq '.build_id' | sed s/\"//g )
+# Truncate it to just the first 10 digits
+BUILD_ID=${BUILD_ID:0:10}
+SOURCE=gcr.io/uwit-mci-iam/husky-directory:deploy-dev.$BUILD_ID
+DEST=gcr.io/uwit-mci-iam/husky-directory:deploy-eval.$BUILD_ID
+docker pull $SOURCE
+docker tag $SOURCE $DEST
+docker push $DEST
+```
 
 ## Image Retention
 
@@ -47,11 +57,16 @@ has access to the project IAM configuration._
 
 ## Running images
 
-Refer to docker documentation for advanced use cases.
+See [Running the app](running-the-app.md).
 
-You can run any published tag:
+## husky-directory-base 
 
-`./scripts/run-development-server.sh -i gcr.io/uwit-mci-iam/husky-directory:${TAG}`
+The application image is built on the [base image](../docker/husky-directory-base.dockerfile).
+Once per week, the base image is rebuilt by default, and tagged with `:edge`.
+
+If you ever want to know what base image was used, you can get that information from 
+the application image's 'HUSKY_DIRECTORY_BASE_VERSION' environment variable. 
+
 
 
 ## development-server dockerfile

--- a/docs/running-the-app.md
+++ b/docs/running-the-app.md
@@ -31,3 +31,24 @@ have to provide this argument.)
 **Running without a valid certificate is not supported at this time.** You can 
 certainly try it, but you won't get very far since the application's main function 
 is to query PWS.
+
+
+## Options
+
+You can run any published tag with `-i`:
+
+`./scripts/run-development-server.sh -i gcr.io/uwit-mci-iam/husky-directory:${TAG}`
+
+You can run an instance that uses a redis cache (for testing and validation
+purposes):
+
+`./.scripts/run-development-server.sh --with-redis`
+
+This will use the [docker-compose file](../docker/docker-compose.app-with-redis.yaml)
+instead of a single docker container. Note that this automatically sets up the
+environment to mount your code live (locally); this is not configurable without editing
+the docker-compose file.
+
+You can run an instance with updated dependencies by providing the `--rebuild-base`
+flag. If you use `poetry add` to include a new dependency, you must use this
+argument in order to run it, until you open a pull request to trigger an update. 

--- a/husky_directory/app_config.py
+++ b/husky_directory/app_config.py
@@ -111,6 +111,7 @@ class RedisSettings(FlaskConfigurationSettings):
         return {
             "SESSION_KEY_PREFIX": f"{self.namespace}:session:",
             "SESSION_REDIS": f"{self.host}:{self.port}",
+            "SESSION_PERMANENT": False,
         }
 
 

--- a/husky_directory/settings/compose-with-redis.dotenv
+++ b/husky_directory/settings/compose-with-redis.dotenv
@@ -1,0 +1,14 @@
+UWCA_CERT_NAME=uwca
+UWCA_CERT_PATH=/app/certificates
+PWS_HOST=https://it-wseval1.s.uw.edu
+PWS_DEFAULT_PATH=/identity/v2
+HOST=uw-directory.iamdev.s.uw.edu
+SAML_ENTITY_ID=https://${HOST}/saml
+SAML_ACS_URL=https://${HOST}/saml/login
+USE_TEST_IDP=1
+
+FLASK_SESSION_TYPE=redis
+REDIS_HOST=redis
+REDIS_PORT=6379
+REDIS_NAMESPACE=directory
+REDIS_PASSWORD=supersecret

--- a/poetry.lock
+++ b/poetry.lock
@@ -255,20 +255,20 @@ docs = ["sphinx"]
 
 [[package]]
 name = "gunicorn"
-version = "20.0.4"
+version = "20.1.0"
 description = "WSGI HTTP Server for UNIX"
 category = "main"
 optional = false
-python-versions = ">=3.4"
+python-versions = ">=3.5"
 
 [package.dependencies]
-gevent = {version = ">=0.13", optional = true, markers = "extra == \"gevent\""}
+gevent = {version = ">=1.4.0", optional = true, markers = "extra == \"gevent\""}
 
 [package.extras]
 tornado = ["tornado (>=0.2)"]
-gevent = ["gevent (>=0.13)"]
+gevent = ["gevent (>=1.4.0)"]
 setproctitle = ["setproctitle"]
-eventlet = ["eventlet (>=0.9.7)"]
+eventlet = ["eventlet (>=0.24.1)"]
 
 [[package]]
 name = "idna"
@@ -510,6 +510,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [[package]]
+name = "redis"
+version = "3.5.3"
+description = "Python client for Redis key-value store"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.extras]
+hiredis = ["hiredis (>=0.1.3)"]
+
+[[package]]
 name = "regex"
 version = "2021.3.17"
 description = "Alternative regular expression module, to replace re."
@@ -636,7 +647,7 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8,<3.9"
-content-hash = "dae0e6f8ca308d8f86968772d4d12afe9adfe6261ac628a703d2f47a36407481"
+content-hash = "9f2f80ff3151b9f9e8b5d1bb5ca62456c70bdcd86b22183c4051109a421ddcfe"
 
 [metadata.files]
 appdirs = [
@@ -872,8 +883,7 @@ greenlet = [
     {file = "greenlet-1.0.0.tar.gz", hash = "sha256:719e169c79255816cdcf6dccd9ed2d089a72a9f6c42273aae12d55e8d35bdcf8"},
 ]
 gunicorn = [
-    {file = "gunicorn-20.0.4-py2.py3-none-any.whl", hash = "sha256:cd4a810dd51bf497552cf3f863b575dabd73d6ad6a91075b65936b151cbf4f9c"},
-    {file = "gunicorn-20.0.4.tar.gz", hash = "sha256:1904bb2b8a43658807108d59c3f3d56c2b6121a701161de0ddf9ad140073c626"},
+    {file = "gunicorn-20.1.0.tar.gz", hash = "sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -1036,6 +1046,10 @@ pyyaml = [
     {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
     {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
+]
+redis = [
+    {file = "redis-3.5.3-py2.py3-none-any.whl", hash = "sha256:432b788c4530cfe16d8d943a09d40ca6c16149727e4afe8c2c9d5580c59d9f24"},
+    {file = "redis-3.5.3.tar.gz", hash = "sha256:0e7e0cfca8660dea8b7d5cd8c4f6c5e29e11f31158c0b0ae91a397f00e5a05a2"},
 ]
 regex = [
     {file = "regex-2021.3.17-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b97ec5d299c10d96617cc851b2e0f81ba5d9d6248413cd374ef7f3a8871ee4a6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ devtools = "^0.6.1"
 python-dotenv = "^0.15.0"
 uw-saml = {version = "^1.0.19"}
 Flask-Session = "^0.3.2"
+redis = "^3.5.3"
 
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"

--- a/scripts/pre-push.sh
+++ b/scripts/pre-push.sh
@@ -15,32 +15,6 @@
 # The variables themselves are used in some helpful output, so that you can copy and paste the output directly to
 # execute other steps.
 #
-# Following is a list of environment variables exported by .pre_push/last:
-#   - COMMIT_SHA: A string containing the first 10 characters of the commit SHA for when this script last succeeded.
-#                 This can be a useful way to construct meaningful commits. See docs/commits.md.
-#                 Example value: ab1c234de5
-#                 How to use it:  git reset ${COMMIT_SHA}
-#
-#   - COMMIT_TAG: A string that contains only the tag name created from your commit message. Useful for comparing to
-#                 to see when your last commit image is from (i.e., at which commit you last ran this script).
-#                 Use this if you want to search for the tag somewhere.
-#                 Example value: commit-ab1c234de5
-#
-#   - COMMIT_IMAGE: A string of the fully qualified image name for this commit. You can push this somewhere if you like,
-#                   or use it to tag another image.
-#                   Example value: uwitiam/husky-directory:commit-ab1c234de5
-#                   How to use it: docker run -it "${COMMIT_IMAGE}"
-#
-#   - PERSONAL_IMAGE: A string similar to COMMIT_IMAGE, but with a tag including your current environment username.
-#                          Example value: uwitiam/husky-directory:personal-foobar
-#                          If you wish for the base to use a different personal name, export or set the
-#                          PERSONAL_IMAGE_SUFFIX environment variable. (e.g., PERSONAL_IMAGE_SUFFIX=justfoo)
-#                          Use this to maintain an image for some personal use case, or deployment environment.
-#                          How to use it: docker tag "${COMMIT_IMAGE}" "${PERSONAL_IMAGE}" \
-#                                             && docker push "${PERSONAL_IMAGE}"
-#
-# There are some options available for running this script; you will see them documented below.
-
 REPO_HOST=gcr.io
 REPO_PROJECT=uwit-mci-iam
 APP_NAME=husky-directory
@@ -48,15 +22,13 @@ SRC_DIR=husky_directory
 TST_DIR=tests
 VIRTUAL_ENV=$(poetry env list --full-path 2>/dev/null | cut -f1 -d\ )
 test -e ${VIRTUAL_ENV}/.envrc && source ${VIRTUAL_ENV}/.envrc
-PERSONAL_IMAGE_SUFFIX=${PERSONAL_IMAGE_SUFFIX:-$USER}
 CACHE_PATH=./.pre_push
 
 for item in "$@"
 do
   case $item in
-    # This will skip some helpful hints in the output. Use this if you want less output and think you know what
-    # you are doing.
-    "--pro")
+    # Hushes a lot of output!
+    "--quiet")
       QUIET=1
       ;;
     # This flag will keep executing the script even if some gateway steps fail
@@ -67,15 +39,18 @@ do
       NO_EXIT_ON_FAIL=1
       NO_COMMIT=1
       ;;
-    # This will prevent creating/overwriting artifact # environment variables.
-    # Only use this if you really don't want the convenience.
-    "--incognito")
-      NO_ENV_VARS=1
+    "--debug")
+      set -x;
       ;;
     # This will prevent some auto-commit features, such as for blackened code or appending the pre-push validation.
     # Not recommended, as it could cause CI to fail if you push code that needed the automatic updates.
     "--no-commit")
       NO_COMMIT=1
+      ;;
+    "--rebuild-base")
+      LOCAL_TAG=gcr.io/uwit-mci-iam/husky-directory-base:local
+      docker build -f docker/husky-directory-base.dockerfile -t $LOCAL_TAG .
+      USE_LOCAL_BASE=1
       ;;
   esac
 done
@@ -107,7 +82,6 @@ COMMIT_TAG="commit-${COMMIT_SHA}"
 conditional_echo "ℹ️ Commit tag is: ${COMMIT_TAG}"
 
 IMAGE_NAME="$REPO_HOST/$REPO_PROJECT/$APP_NAME:$COMMIT_TAG"
-PERSONAL_IMAGE="$DOCKER_ORG/$APP_NAME:personal-$PERSONAL_IMAGE_SUFFIX"
 
 if ! black --check $SRC_DIR $TST_DIR > /dev/null
 then
@@ -126,7 +100,11 @@ else
 fi
 
 conditional_echo "Building development server image"
-docker build -f docker/development-server.dockerfile -t "${IMAGE_NAME}" .
+if [[ -n "$USE_LOCAL_BASE" ]]
+then
+  BUILD_ARGS="${BUILD_ARGS} --build-arg BASE_VERSION=local"
+fi
+docker build -f docker/development-server.dockerfile ${BUILD_ARGS} -t "${IMAGE_NAME}" .
 conditional_echo "Tagged image ${IMAGE_NAME}"
 if ! docker run -v "$(pwd)"/htmlcov:/app/htmlcov -it "${IMAGE_NAME}" /scripts/validate-development-image.sh
 then
@@ -141,40 +119,6 @@ then
 fi
 
 test -z "${NO_EXIT_ON_FAIL}" && echo "🛳 Your commit is good to go! 🌈"
-
-if test -z "${NO_ENV_VARS}"
-then
-  artifact=${CACHE_PATH}/${COMMIT_SHA}
-  conditional_echo "ℹ️ Creating ${artifact}; you can source this to re-populate environment variables later."
-  echo "#!/usr/bin/env sh" > $artifact
-  echo "export COMMIT_SHA=${COMMIT_SHA}" >> $artifact
-  echo "export COMMIT_IMAGE=${IMAGE_NAME}" >> $artifact
-  echo "export PERSONAL_IMAGE=${PERSONAL_IMAGE}" >> $artifact
-  echo "export COMMIT_TAG=${COMMIT_TAG}" >> $artifact
-  conditional_echo "Symlinking ${artifact} to .pre_push/last"
-  pushd $CACHE_PATH
-    ln -s -f ${COMMIT_SHA} last
-  popd
-fi
-
-
-if test -z "${QUIET}"
-then
-  echo ""
-  echo "OPTIONAL NEXT STEPS: "
-  echo "  - Populate environment variables from this run: source .pre_push/last"
-  echo "  - Tag the image for a personal instance: docker tag \${COMMIT_IMAGE} \${PERSONAL_IMAGE}"
-  echo "    then push the personal image for live testing: docker push \${PERSONAL_IMAGE}"
-  echo "    then visit https://directory-${PERSONAL_IMAGE_SUFFIX}.iamdev.s.uw.edu"
-  echo "  - Push to remote: git push "
-  echo "    then create a code review: https://github.com/UWIT-IAM/uw-husky-directory/compare"
-  echo ""
-  if test -n "${NO_ENV_VARS}"
-  then
-    echo "❗️You ran this with --no-env, which means the environment variables exemplified above are NOT set."
-    conditional_echo "If you want to make use of them, simply run this script again, without the '--no-env' flag."
-  fi
-fi
 
 if test -n "${NO_EXIT_ON_FAIL}"
 then

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -7,6 +7,7 @@ from injector import Injector
 from husky_directory.app_config import (
     ApplicationConfig,
     ApplicationSecrets,
+    RedisSettings,
     YAMLSettingsLoader,
 )
 
@@ -64,3 +65,13 @@ class TestYAMLSettingsLoader:
         self.loader.app_config.stage = "error"
         with pytest.raises(KeyError):
             self.test_yaml_settings_loader()
+
+
+class TestRedisSettings:
+    def test_flask_config_values(self):
+        settings = RedisSettings(host="redis", namespace="directory")
+        assert settings.flask_config_values == {
+            "SESSION_KEY_PREFIX": "directory:session:",
+            "SESSION_REDIS": "redis:6379",
+            "SESSION_PERMANENT": False,
+        }


### PR DESCRIPTION
Supports EDS-583, but will not fully resolve it on its own. This will also require a change to gcp-k8 for the full effect to test a redis-backed cache in dev before promoting the same change to eval.

**This change allows the application to use a redis cache if the `FLASK_SESSION_TYPE` environment variable is set to `redis`.** This required a little hackery because the default flask_sessions redis implementation does not cover auth for password-protected redis instances, but it's overall a small change.

Other changes that were inside the blast radius:

- Create a local instance using redis by adding `--with-redis` to your `run-development-server.sh` command.
- Support for using a locally rebuilt base image for cases where dependencies change  (`--rebuild-base`)
- Support fingerprinting the base image for traceability