### PR TITLE
[EDS-581] Add support for addresses in vcard export

### DIFF
--- a/docs/jinja-templates.md
+++ b/docs/jinja-templates.md
@@ -1,0 +1,130 @@
+# Jinja Templates
+
+## Custom Filters
+
+### `titleize`
+
+```
+'foo_bar' == becomes ==> 'Foo Bar'
+'fooBar' == becomes ==> 'Foo Bar'
+```
+
+### `singularize`
+
+```
+'foos' == becomes ==> 'foo'
+'faculty' == becomes ==> 'faculty'
+```
+
+### linkify
+
+```
+'foo bar baz' == becomes ==> 'foo-bar-baz'
+```
+
+### externalize
+
+We present the "employee" population as "faculty/staff;" this filter
+can be used to register other strings that, when encountered, should be 
+presented another way.
+
+```
+'employees' == becomes ==> 'faculty/staff'
+'something else' == becomes ==> 'something else'
+```
+
+## Custom predicates
+
+### `blank`
+
+Returns `True` if value is either undefined _or_ set to `None`.
+
+
+
+## Helpful Hints
+
+### Whitespace Control
+
+To control whitespace in jinja templates, you have to undersatnd it. 
+
+If you type:
+
+```
+{% for foo in bar %}
+    (
+    {{ foo }}
+    )\n
+{% endfor %}
+```
+
+Jinja sees:
+
+```
+{% for foo in bar %}\n
+    (\n
+    {{ foo }}\n
+    )\n
+{% endfor %}\n
+```
+
+Jinja will not assume you want those newlines trimmed. 
+To trim them, you have to use the `-` modifier.
+
+In `{% for foo in bar %}\n`, we can strip `\n` by using `-%}`, which means 
+"strip the newline you're about to encounter." 
+
+So: Use `-%}` or `-}}` to indicate you want jinja to ignore the _next_
+newline that is encountered.
+
+Use `{%-` or `{{-` to ignore the _previous_ newline that was encountered.
+
+In the above example, with `bar=[1,2,3,4]` we could:
+
+#### Render each block on its own line
+
+```
+{% for foo in bar -%}
+    (
+    {{- foo -}}
+    )
+{%- endfor %}\n
+```
+
+looks to Jinja like:
+
+
+```
+{% for foo in bar -%}
+    (
+    {{- foo -}}
+    )
+{%- endfor %}\n
+```
+
+So the result is:
+
+```
+(1)
+(2)
+(3)
+(4)
+```
+
+#### Render the whole block on a single line:
+
+Same as above, but we remove the last newline as well:
+
+```
+{% for foo in bar -%}
+(
+{{- foo -}}
+)
+{%- endfor -%}
+```
+
+has no newlines (unless there was a newline prior to this block) 
+so the output would render as:
+
+```
+(1)(2)(3)(4)
+```

--- a/husky_directory/app.py
+++ b/husky_directory/app.py
@@ -148,6 +148,8 @@ class AppInjectorModule(Module):
 
         # We've done our pre-work; now we can create the instance itself.
         app = Flask("husky_directory")
+        app.jinja_env.trim_blocks = True
+        app.jinja_env.lstrip_blocks = True
         app.config.update(app_settings.app_configuration)
         app.url_map.strict_slashes = (
             False  # Allows both '/search' and '/search/' to work

--- a/husky_directory/models/base.py
+++ b/husky_directory/models/base.py
@@ -19,6 +19,9 @@ class PropertyBaseModel(BaseModel):
     https://github.com/samuelcolvin/pydantic/issues/935#issuecomment-752987593
     """
 
+    class Config:
+        ignored_properties = []
+
     @classmethod
     def get_properties(cls) -> typing.List[str]:
         """
@@ -28,7 +31,8 @@ class PropertyBaseModel(BaseModel):
         return [
             prop
             for prop in dir(cls)
-            if isinstance(getattr(cls, prop), property)
+            if prop not in getattr(cls.Config, "ignored_properties", [])
+            and isinstance(getattr(cls, prop), property)
             and prop not in ("__values__", "fields")
         ]
 

--- a/husky_directory/models/pws.py
+++ b/husky_directory/models/pws.py
@@ -128,6 +128,7 @@ class EmployeeDirectoryListing(PWSBaseModel):
     touch_dials: List[str] = []
     pagers: List[str] = []
     mobiles: List[str] = []
+    addresses: List[str] = []
 
 
 class StudentDirectoryListing(PWSBaseModel):

--- a/husky_directory/models/vcard.py
+++ b/husky_directory/models/vcard.py
@@ -1,5 +1,10 @@
+from __future__ import annotations
+
+import re
 from enum import Enum
 from typing import List, Optional
+
+from pydantic import validator
 
 from husky_directory.models.base import DirectoryBaseModel
 
@@ -19,6 +24,83 @@ class VCardPhone(DirectoryBaseModel):
     value: str
 
 
+class VCardAddress(DirectoryBaseModel):
+    box_number: Optional[str]
+    ext_address: Optional[str]
+    street_address: Optional[str]
+    city: Optional[str]
+    state: Optional[str]
+    zip_code: Optional[str]
+    country: Optional[str]
+
+    class Config(DirectoryBaseModel.Config):
+        # Causes a recursion error if not ignored, because
+        # dict() fetches property values, and this property
+        # calls dict()
+        validate_assignment = True
+        ignored_properties = ["vcard_format"]
+
+    @validator("box_number", always=True)
+    def normalize_box_number(cls, box_number: Optional[str]) -> Optional[str]:
+        if box_number:
+            return f"Box {box_number}"
+        return None
+
+    @property
+    def vcard_format(self) -> str:
+        fmt_map = {  # Replace None values with empty strings
+            k: (v if v else "") for k, v in self.dict().items()
+        }
+        return (
+            "{box_number};{ext_address};{street_address};"
+            "{city};{state};{zip_code};{country};".format_map(fmt_map)
+        )
+
+    @classmethod
+    def from_string(
+        cls, address_string: str, box_number: Optional[str] = None
+    ) -> VCardAddress:
+        """
+        Attempts to parse the address value into its component fields; it doesn't try too hard to do this.
+        It is acceptable (for us) for the entire address to simply be included as a street address.
+        If not provided, the state field is assumed to be WA and the country is assumed to be US.
+
+        The heuristic for parsing the address is simple:
+            - If it ends in a zip code, we will assume it has the pattern 'City, ST ZIP'
+            - Next we look to the token where we expect the "City," string to be based on its position relative to
+              the zip code checking if it ends with a comma. If it does, we can assume it is the city,
+              and the token after is the state.
+            - Everything else, we treat as the street address.
+
+        If any of the above tests fails, then we simply set whatever we haven't parsed as a street address.
+        (Compared to the incumbent product which never tries to parse it, this gives us a slight edge over parity
+        as the successor.)
+        """
+        # ['4501', '15th', 'Ave', 'NE', 'Seattle,', 'WA', '98105-4527']
+        address_parts = address_string.split()
+        end_index = -1
+        instance = cls(
+            box_number=box_number,
+            state="WA",
+            country="US",
+            street_address=address_string,
+        )
+        zip_match = re.match(r"^[0-9\-]{5,10}", address_parts.pop(end_index))
+        if zip_match:
+            instance.zip_code = zip_match.string
+            city_token_index = -2  # zip has already been popped
+            city_match = address_parts[city_token_index]
+            if city_match.endswith(","):
+                # Don't pop city token unless we know it's legit,
+                # otherwise, we consume the city and it is never
+                # included in the output.
+                address_parts.pop(city_token_index)
+                instance.city = city_match[:end_index]
+                instance.state = address_parts.pop(end_index)
+            instance.street_address = " ".join(address_parts)
+        return instance
+
+
 class VCard(DirectoryBaseModel):
     last_name: str
     name_extras: List[str] = []
@@ -27,3 +109,4 @@ class VCard(DirectoryBaseModel):
     departments: List[str] = []
     email: Optional[str]
     phones: List[VCardPhone] = []
+    addresses: List[str] = []

--- a/husky_directory/templates/vcard.vcf.jinja2
+++ b/husky_directory/templates/vcard.vcf.jinja2
@@ -1,28 +1,34 @@
-{#
-    Do not adhere to conventional indendation in this file.
-    Line breaks for long lines must only happen _inside_ jinja blocks.
-    field must be on a single line, with no indents.
-    Specification: https://tools.ietf.org/html/rfc6350
-    Model: husky_directory.models.vcard.VCard
-#}
+{# Be careful when adding new blocks, make sure to remove
+any whitespaces using the built-in jinja whitespace control.
+For more, see docs/jinja-templates.md#whitespace-control #}
 BEGIN:VCARD
 {# "Husky Dawg Woofington" becomes "woofington;husky;dawg" #}
-N:{{ last_name }};{% for e in name_extras %}{{ e }}{{';' if not loop.last else '' }}{% endfor %}
+N:{{ last_name }};{% for e in name_extras -%}
+    {{ e }}{{ ';' if not loop.last else '' }}
+{% endfor %}
 {# Husky Dawg Woofington #}
 FN:{{ display_name }}
-{% for title in titles %}
-TITLE:{{ title }}
+{% for title in titles -%}
+    TITLE:{{ title }}
 {% endfor %}
-{% for dept in departments %}
-ORG:University of Washington;{{ dept }}
+{% for dept in departments -%}
+    ORG:University of Washington;{{ dept }}
 {% endfor %}
-{% if not email is blank %}
 {# EMAIL;type=INTERNET,type=WORK:dawg@uw.edu #}
-EMAIL;type=INTERNET,type=WORK:{{ email }}
+{% if not email is blank -%}
+    EMAIL;type=INTERNET,type=WORK:{{ email }}
 {% endif %}
-{% for phone in phones %}
 {# TEL;type="pager,voice":5558675309 #}
-TEL;type="{% for pt in phone['types'] %}{{ pt }}{{
-        ',' if not loop.last else '' }}{% endfor %}":{{ phone['value'] }}
-{% endfor %} {# phone in phones #}
+{% for phone in phones -%}
+    TEL;type="{% for pt in phone['types'] -%}
+        {{ pt }}{{ ',' if not loop.last else '' }}
+    {%- endfor %}":{{ phone['value'] }}
+{% endfor -%} {# phone in phones #}
+{# `vcard_address` is a preformatted string using the following format:
+ # [PO Box];[Extended Address];[Street Address];[City];[State];[ZIP Code];[Country]
+#}
+{% for vcard_address in addresses -%}
+    item{{ loop.index }}.X-ABADR:us
+    item{{ loop.index }}.ADR;type=WORK:{{ vcard_address }}
+{% endfor %}
 END:VCARD

--- a/tests/models/test_vcard_models.py
+++ b/tests/models/test_vcard_models.py
@@ -1,0 +1,37 @@
+import pytest
+
+from husky_directory.models.vcard import VCardAddress
+
+
+class TestVCardAddress:
+    @pytest.fixture(autouse=True)
+    def initialize(self):
+        pass
+
+    @pytest.mark.parametrize(
+        "pws_value, box_number, expected",
+        [
+            # Standard address formatting
+            (
+                "123 Main St. Anytown, WA 12345-1234",
+                "351234",
+                "Box 351234;;123 Main St.;Anytown;WA;12345-1234;US;",
+            ),
+            # Has accurate zip, but city/state not parseable, so uses defaults
+            # and includes original as street address
+            (
+                "123 Main St. Anytown WA 12345",
+                None,
+                ";;123 Main St. Anytown WA;;WA;12345;US;",
+            ),
+            # No zip parseable, so all parsing fails; defaults used
+            # for state/country; original used as street address
+            (
+                "123 Main St. Anytown, WA",
+                "351235",
+                "Box 351235;;123 Main St. Anytown, WA;;WA;;US;",
+            ),
+        ],
+    )
+    def test_from_string(self, pws_value, box_number, expected):
+        assert VCardAddress.from_string(pws_value, box_number).vcard_format == expected

--- a/tests/services/test_vcard.py
+++ b/tests/services/test_vcard.py
@@ -32,6 +32,7 @@ def employee(generate_person) -> PersonOutput:
         netid="employee",
         affiliations=PersonAffiliations.construct(
             employee=EmployeePersonAffiliation(
+                mail_stop="381234",
                 directory_listing=EmployeeDirectoryListing(
                     publish_in_directory=True,
                     phones=["1111111"],
@@ -41,7 +42,8 @@ def employee(generate_person) -> PersonOutput:
                     touch_dials=["3333333"],
                     emails=["employee@uw.edu"],
                     positions=positions,
-                )
+                    addresses=["123 Main St. Anytown, WA 98123"],
+                ),
             )
         ),
     )
@@ -142,6 +144,8 @@ class TestVCardServiceVCardGeneration:
             'TEL;type="cell,pager,work":1111111',
             'TEL;type="TTY-TDD":3333333',
             'TEL;type="fax":2222222',
+            "item1.X-ABADR:us",
+            "item1.ADR;type=WORK:Box 381234;;123 Main St.;Anytown;WA;98123;US;",
             "END:VCARD",
         ]
 
@@ -281,6 +285,8 @@ class TestVCardServiceVCardGeneration:
             'TEL;type="cell,pager,work":1111111',
             'TEL;type="TTY-TDD":3333333',
             'TEL;type="fax":2222222',
+            "item1.X-ABADR:us",
+            "item1.ADR;type=WORK:Box 381234;;123 Main St.;Anytown;WA;98123;US;",
             "END:VCARD",
         ]
 


### PR DESCRIPTION
Closes EDS-581

- Consume addresses from PWS output
- Add model to convert stringy address into a best-guess vcard-formatted string
- Update vcard template to use whitespace control so the template could look nicer
- Add jinja2 documentation to capture some custom filters, and the things i learned about whitespace control
- Add tests for address formatting
- Add tests for addresses in vcards