### PR TITLE
[EDS-584][ICEBERG] Fix bug in search result filtering

### DIFF
--- a/husky_directory/blueprints/search.py
+++ b/husky_directory/blueprints/search.py
@@ -2,7 +2,7 @@ from base64 import b64decode
 from logging import Logger
 from typing import Optional
 
-from flask import Blueprint, Request, jsonify, render_template, send_file
+from flask import Blueprint, Request, jsonify, redirect, render_template, send_file
 from inflection import humanize, underscore
 from injector import Injector, inject, singleton
 from pydantic import ValidationError
@@ -72,6 +72,9 @@ class SearchBlueprint(Blueprint):
 
         Returns a jsonified instance of SearchDirectoryOutput
         """
+        if not request.args:
+            return redirect("/")
+
         request_input = SearchDirectoryInput.parse_obj(request.args)
         self.logger.info(f"searching for {request_input}")
         request_output = search_service.search_directory(request_input)

--- a/husky_directory/models/common.py
+++ b/husky_directory/models/common.py
@@ -5,7 +5,15 @@ the behavior itself is truly common. Otherwise, those behaviors
 should be declared in an inheriting subclass within the context of
 the respective service model.
 """
-from pydantic import BaseModel
+from __future__ import annotations
+
+import json
+import re
+from types import SimpleNamespace
+from typing import Any, Callable, Generic, Optional, TypeVar, Union
+
+from pydantic import BaseModel, validator
+from pydantic.generics import GenericModel
 
 
 class UWDepartmentRole(BaseModel):
@@ -16,3 +24,117 @@ class UWDepartmentRole(BaseModel):
 
     title: str
     department: str
+
+
+namespace_regex = re.compile(r"^([\w\d_]+\.?)+$")
+
+
+class RecordNamespace(str):
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v) -> RecordNamespace:
+        if v and (not namespace_regex.match(v) or v.endswith(".")):
+            raise ValueError(
+                "Constraint namespace must be in the format: `attr_1.attr_2.attr_3`"
+            )
+        return v
+
+
+T = TypeVar("T")
+
+
+class RecordConstraint(GenericModel, Generic[T]):
+    """
+    This model helps us apply additional client-side filters to
+    result records. A record can be an object or a dict.
+
+    This allows fine-grained filtering control, which in our
+    case here allows us to filter our records based on constraints
+    that cannot be directly queried in PWS.
+
+    `namespace` is a dot-notated path to the attribute
+    being tested for a given record.
+
+    `predicate` is a function that accepts some argument
+    and returns a boolean result. At runtime, the value
+    will be extracted from the record, using its namespace,
+    and the result will be returned.
+
+    `failure_callback` is an alternative to rejecting a record,
+    and if set has the opportunity to update the record. This can
+    allow filtering of specific attributes inside the record without
+    rejecting the record itself. If the function does not return a
+    value of True, the output will still be rejected!
+
+    Example:
+        data_1 = {"foo": {"bar": "baz" } }
+        data_2 = {"foo": {"bar": None } }
+
+        def callback(record: PersonOutput):
+            record['foo']['bar'] = 'temp'
+            return True
+
+        predicate = lambda x: x == 'baz'
+
+        constraint = RecordConstraint(
+            namespace = 'foo.bar',
+            predicate=predicate,
+            failure_callback
+        )
+
+        assert onstraint.matches(data_1)
+        assert data_1['foo']['bar'] == 'baz'
+
+        assert constraint.matches(data_2)
+        assert data_2['foo']['bar'] == 'temp'
+    """
+
+    namespace: Union[
+        RecordNamespace, str
+    ]  # Will always be converted to a RecordNamespace
+    predicate: Callable[[T], bool] = lambda _: False
+    failure_callback: Callable[[T], bool] = lambda _: False
+
+    def resolve_namespace(self, record: Any) -> Optional[Any]:
+        """
+        Given a record, resolves the value of the namespace. The record can be anything.
+        If it is a dict, the dict will be evaluated as namespace for the scope of this method.
+
+        This will never fail to resolve; at worst, the value will be None.
+        This is by design, although strict resolution could be added as a feature in the
+        future if needed. It is heavy to do so, and not needed today.
+        :param record: The thing you want to test; it can be anything!
+        :return: The value of the resolved namespace, or None.
+        """
+        if isinstance(record, dict):
+            # Converts the dict into an object.
+            record = json.loads(
+                json.dumps(record), object_hook=lambda item: SimpleNamespace(**item)
+            )
+
+        resolved = record
+
+        for token in self.namespace.split("."):
+            resolved = getattr(resolved, token, None)
+            if not resolved:
+                break
+        return resolved
+
+    def matches(self, record: T) -> bool:
+        """
+        Given a thing, returns whether the thing matches the predicate
+        or the failure callback.
+        :param record: The thing you want to filter.
+        :return: Whether or not the test(s) succeeded.
+        """
+        resolved = self.resolve_namespace(record)
+        return self.predicate(resolved) or self.failure_callback(record)
+
+    @validator("namespace", always=True)
+    def validate_namespace(cls, v: Union[str, RecordNamespace]) -> RecordNamespace:
+        if not isinstance(v, RecordNamespace):
+            return RecordNamespace.validate(v)
+        return v

--- a/husky_directory/models/pws.py
+++ b/husky_directory/models/pws.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional
 from inflection import titleize
 from pydantic import BaseModel, Extra, Field, validator
 
-from .common import UWDepartmentRole
+from .common import RecordConstraint, UWDepartmentRole
 from .enum import AffiliationState
 from ..util import camelize
 
@@ -106,6 +106,7 @@ class ListPersonsInput(PWSBaseModel):
         "PWS response to indicate the next page of a large query.",
         alias="Href",
     )
+    constraints: List[RecordConstraint] = []
 
 
 class EmployeePosition(PWSBaseModel, UWDepartmentRole):
@@ -165,7 +166,7 @@ class NamedIdentity(PWSBaseModel):
     registered_first_middle_name: Optional[str]
     preferred_first_name: Optional[str]
     preferred_middle_name: Optional[str]
-    preferred_last_name: Optional[str]
+    preferred_last_name: Optional[str] = Field(None, alias="PreferredSurname")
 
     @validator(
         "display_name",

--- a/husky_directory/services/auth.py
+++ b/husky_directory/services/auth.py
@@ -1,0 +1,19 @@
+from flask_injector import request
+from injector import inject
+from werkzeug.local import LocalProxy
+
+
+@request
+class AuthService:
+    """
+    A simple little service to tell you whether or not
+    the current request has been authenticated.
+    """
+
+    @inject
+    def __init__(self, session: LocalProxy):
+        self.session = session
+
+    @property
+    def request_is_authenticated(self) -> bool:
+        return bool(self.session.get("uwnetid"))

--- a/husky_directory/services/pws.py
+++ b/husky_directory/services/pws.py
@@ -1,22 +1,33 @@
 import os
 from collections import namedtuple
+from functools import partial
 from logging import Logger
-from typing import Dict, Optional, Type, TypeVar
+from typing import Any, Dict, List, Optional, Type, TypeVar, Union, cast
 
 import requests
 from devtools import PrettyFormat
-from injector import inject, singleton
+from flask_injector import request
+from injector import inject
+from werkzeug.exceptions import NotFound
 
 from husky_directory.app_config import ApplicationConfig
-from husky_directory.models.pws import ListPersonsInput, ListPersonsOutput, PWSBaseModel
+from husky_directory.models.common import RecordConstraint
+from husky_directory.models.pws import (
+    ListPersonsInput,
+    ListPersonsOutput,
+    PersonOutput,
+)
+from husky_directory.services.auth import AuthService
 
 RequestsCertificate = namedtuple("RequestsCertificate", ["cert_path", "key_path"])
 
 
-OutputReturnType = TypeVar("OutputReturnType", bound=PWSBaseModel)
+OutputReturnType = TypeVar(
+    "OutputReturnType", bound=Union[ListPersonsOutput, PersonOutput]
+)
 
 
-@singleton
+@request
 class PersonWebServiceClient:
     @inject
     def __init__(
@@ -24,6 +35,7 @@ class PersonWebServiceClient:
         application_config: ApplicationConfig,
         logger: Logger,
         formatter: PrettyFormat,
+        auth: AuthService,
     ):
         uwca_cert_path = application_config.auth_settings.uwca_cert_path
         uwca_cert_name = application_config.auth_settings.uwca_cert_name
@@ -35,10 +47,44 @@ class PersonWebServiceClient:
         self.default_path = application_config.pws_settings.pws_default_path
         self.logger = logger
         self.formatter = formatter
+        self.auth = auth
 
     @property
     def pws_url(self):
         return f"{self.host}{self.default_path}"
+
+    def _get_sanitized_request_output(
+        self,
+        url: str,
+        params: Optional[Dict] = None,
+        constraints: Optional[List[RecordConstraint]] = None,
+        output_type: Type[OutputReturnType] = ListPersonsOutput,
+    ) -> OutputReturnType:
+        """
+        Applies filters to the output. This puts almost all of the filtering
+        right above the request layer using a unified interface, as opposed to
+        filtering in different ways at different times.
+
+        Essentially, we know that in the Cloud Native Directory product, we always want to
+        apply certain filters against the data, so we will prune it right at the source so that
+        the other services in our application don't have to validate data state.
+
+        :return: The output; always returns a value, unless PWS raises an error.
+        """
+        constraints = constraints or self.global_constraints
+        output = self._get_search_request_output(url, params, output_type)
+        if output_type is ListPersonsOutput:
+            output = cast(ListPersonsOutput, output)
+            # Post-process the output to remove items that do not meet
+            # the provided client-side constraints.
+            output.persons = list(
+                filter(partial(self._filter_output_item, constraints), output.persons)
+            )
+        elif output_type is PersonOutput:
+            output = cast(PersonOutput, output)
+            if not self._filter_output_item(constraints, output):
+                raise NotFound
+        return output
 
     def _get_search_request_output(
         self,
@@ -55,6 +101,18 @@ class PersonWebServiceClient:
         output = output_type.parse_obj(data)
         return output
 
+    def _filter_output_item(
+        self, constraints: List[RecordConstraint], target: PersonOutput
+    ) -> bool:
+        if target.affiliations.student and not self.auth.request_is_authenticated:
+            target.affiliations.student = None
+
+        for constraint in constraints:
+            if not constraint.matches(target):
+                return False
+
+        return bool(target.affiliations.student) or bool(target.affiliations.employee)
+
     def get_explicit_href(
         self, page_url: str, output_type: Type[OutputReturnType] = ListPersonsOutput
     ) -> OutputReturnType:
@@ -68,9 +126,74 @@ class PersonWebServiceClient:
                 while list_persons_output.next:
                     list_persons_output = get_explicit_href(list_persons_output.next.href)
         """
-        return self._get_search_request_output(
+        return self._get_sanitized_request_output(
             f"{self.host}{page_url}", output_type=output_type
         )
+
+    @property
+    def global_constraints(self) -> List[RecordConstraint]:
+        """
+        These constraints are applied to every public request method in this application.
+        """
+
+        def clear_namespace(namespace, record: Any) -> bool:
+            """
+            This callback allows attributes to be cleared if they
+            do not match the criteria, instead of throwing away the entire record.
+            Practically: if the user has opted out of employee or student publication,
+            then we null the respective attributes.
+            """
+            ns = namespace.split(".")
+            attr = ns.pop(
+                -1
+            )  # Allows us to resolve to the level _above_ the field being cleared
+            constraint = RecordConstraint.construct(namespace=".".join(ns))
+            field = constraint.resolve_namespace(record)
+            if field:
+                setattr(field, attr, None)
+            return True
+
+        return [
+            RecordConstraint(
+                # If the identity has no netid, we are not interested
+                # in the record.
+                namespace="netid",
+                predicate=bool,
+            ),
+            RecordConstraint(
+                # If the identity is not eligible for publication,
+                # we are not interested in the record.
+                namespace="whitepages_publish",
+                predicate=bool,
+            ),
+            RecordConstraint(
+                # TODO: Support including test entities here,
+                # which will need a minor refactor of how that param
+                # is passed around. For now, we simply invert
+                # the bool representation: if we have a test entity,
+                # then we return False (and exclude the record).
+                namespace="is_test_entity",
+                predicate=lambda v: not bool(v),
+            ),
+            RecordConstraint(
+                # If there is a student affiliation and the affiliation's
+                # publication flag is true, then accept it;
+                # otherwise clear the affiliation from the record and
+                # continue processing.
+                namespace="affiliations.student.directory_listing.publish_in_directory",
+                predicate=bool,
+                failure_callback=partial(clear_namespace, "affiliations.student"),
+            ),
+            RecordConstraint(
+                # If there is an employee affiliation and the affiliation's
+                # publication flag is true, then accept it;
+                # otherwise clear the affiliation from the record and
+                # continue processing.
+                namespace="affiliations.employee.directory_listing.publish_in_directory",
+                predicate=bool,
+                failure_callback=partial(clear_namespace, "affiliations.employee"),
+            ),
+        ]
 
     def list_persons(self, request_input: ListPersonsInput) -> ListPersonsOutput:
         """
@@ -78,7 +201,12 @@ class PersonWebServiceClient:
         For more information on this request,
         see https://it-wseval1.s.uw.edu/identity/swagger/index.html#/PersonV2/PersonSearch
         """
-        request_input = request_input.payload
+        payload = request_input.payload
+        constraints = self.global_constraints + request_input.constraints
+
         url = f"{self.pws_url}/person"
-        output = self._get_search_request_output(url, request_input)
+        output = self._get_sanitized_request_output(
+            url, payload, constraints=constraints
+        )
+
         return output

--- a/husky_directory/util.py
+++ b/husky_directory/util.py
@@ -1,3 +1,5 @@
+from typing import TypeVar
+
 import inflection
 from devtools.debug import PrettyFormat
 from injector import Module, provider, singleton
@@ -22,3 +24,40 @@ class UtilityInjectorModule(Module):
 def camelize(string: str, uppercase_first_letter=False) -> str:
     """Fixes the default behavior to keep the first character lowerCased."""
     return inflection.camelize(string, uppercase_first_letter=uppercase_first_letter)
+
+
+T = TypeVar("T")
+
+
+class ConstraintPredicates:
+    """Commonly used predicates for output constraints"""
+
+    @staticmethod
+    def normalize_strings(*args: T) -> T:
+        for arg in args:
+            if isinstance(arg, str):
+                yield arg.lower()
+            else:
+                yield arg
+
+    @staticmethod
+    def null_or_begins_with(target: str, value: str) -> bool:
+        target, value = ConstraintPredicates.normalize_strings(target, value)
+        return not value or value.startswith(target)
+
+    @staticmethod
+    def null_or_matches(target: str, value: str) -> bool:
+        target, value = ConstraintPredicates.normalize_strings(target, value)
+        return not value or value == target
+
+    @staticmethod
+    def matches(target: str, value: str) -> bool:
+        target, value = ConstraintPredicates.normalize_strings(target, value)
+        return target == value
+
+    @staticmethod
+    def null_or_includes(target: str, value: str) -> bool:
+        target, value = ConstraintPredicates.normalize_strings(target, value)
+        if isinstance(value, (list, set)):
+            value = list(ConstraintPredicates.normalize_strings(*value))
+        return not value or target in value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,9 +59,8 @@ def app(
 
 @pytest.fixture
 def generate_person():
-    random_string = "".join(random.choice(string.ascii_lowercase) for _ in range(24))
-
     def inner(**attrs: Any) -> PersonOutput:
+        random_string = "".join(random.choice(string.ascii_lowercase) for _ in range(8))
         default = PersonOutput(
             display_name="Ada Lovelace",
             registered_name="Ada Lovelace",
@@ -69,7 +68,7 @@ def generate_person():
             registered_first_middle_name="Ada",
             whitepages_publish=True,
             is_test_entity=False,
-            netid="ada",
+            netid=random_string,
             href=f"person/{random_string}",
         )
         return default.copy(update=attrs)
@@ -135,12 +134,22 @@ def mock_people(generate_person):
                         faxes=["+1 999 214-9864"],
                         mobiles=["+1 999 (967)-4222", "+1 999 (967) 4999"],
                         touch_dials=["+19999499911"],
-                        emails=["dawg@uw.edu"],
+                        emails=["dawg@uw.edu", "dawg2@uw.edu"],
+                        voice_mails=["1800MYVOICE"],
+                        positions=[
+                            EmployeePosition(
+                                department="Haute Cuisine", title="Garde Manger"
+                            ),
+                        ],
                     ),
                 ),
                 student=StudentPersonAffiliation(
                     directory_listing=StudentDirectoryListing(
-                        publish_in_directory=True, phone="19999674222"
+                        publish_in_directory=True,
+                        phone="19999674222",
+                        email="student@uw.edu",
+                        departments=["Cybertronic Engineering"],
+                        class_level="Junior",
                     )
                 ),
             )

--- a/tests/models/test_common_models.py
+++ b/tests/models/test_common_models.py
@@ -1,0 +1,34 @@
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+from husky_directory.models.common import RecordConstraint
+
+
+class TestRecordConstraint:
+    @pytest.mark.parametrize(
+        "record",
+        [
+            {"foo": "bar", "baz": {"bop": "buzz"}},
+            SimpleNamespace(foo="bar", baz=SimpleNamespace(bop="buzz")),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "namespace, expected_value",
+        [
+            ("foo", "bar"),
+            ("foo.bar", None),  # Bar is not an attribute
+            ("baz.bop", "buzz"),
+        ],
+    )
+    def test_resolve_namespace(self, namespace, record, expected_value):
+        constraint = RecordConstraint(
+            namespace=namespace,
+        )
+        assert constraint.resolve_namespace(record) == expected_value
+
+    @pytest.mark.parametrize("invalid_input", ["foo.", "foo-bar"])
+    def test_invalid_namespace(self, invalid_input):
+        with pytest.raises(ValidationError):
+            RecordConstraint(namespace=invalid_input)

--- a/tests/services/test_auth_service.py
+++ b/tests/services/test_auth_service.py
@@ -1,0 +1,23 @@
+import pytest
+from werkzeug.local import LocalProxy
+
+from husky_directory.services.auth import AuthService
+
+
+class TestAuthService:
+    @pytest.fixture(autouse=True)
+    def configure(self, mock_injected, injector):
+        self.session = {}
+        with mock_injected(LocalProxy, self.session):
+            self.service = injector.get(AuthService)
+
+    @pytest.mark.parametrize(
+        "uwnetid, expected_result",
+        [
+            ("foo", True),
+            (None, False),
+        ],
+    )
+    def test_request_is_authenticated(self, uwnetid, expected_result):
+        self.session["uwnetid"] = uwnetid
+        assert self.service.request_is_authenticated == expected_result

--- a/tests/services/test_pws.py
+++ b/tests/services/test_pws.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 import requests
 
-from husky_directory.models.pws import ListPersonsInput, ListPersonsOutput
+from husky_directory.models.pws import ListPersonsInput
 from husky_directory.services.pws import PersonWebServiceClient
 
 
@@ -23,19 +23,16 @@ class TestPersonWebServiceClient:
 
     def test_get_explicit_href(self):
         expected_url = f"{self.client.pws_url}/foobar"
-
         self.client.get_explicit_href("/identity/v2/foobar")
-        self.mock_send_request.assert_called_once_with(
-            expected_url, output_type=ListPersonsOutput
-        )
+        self.mock_send_request.assert_called_once()
+        assert self.mock_send_request.call_args[0][0] == expected_url
 
     def test_list_persons(self):
         request_input = ListPersonsInput(display_name="test")
-        self.client.list_persons(request_input)
         expected_url = f"{self.client.pws_url}/person"
-        self.mock_send_request.assert_called_once_with(
-            expected_url, request_input.payload
-        )
+        self.client.list_persons(request_input)
+        self.mock_send_request.assert_called_once()
+        assert self.mock_send_request.call_args[0][0] == expected_url
 
     def test_get_search_request_output(self):
         mock_params = dict(abra="cadabra")

--- a/tests/services/test_search.py
+++ b/tests/services/test_search.py
@@ -1,5 +1,4 @@
 from contextlib import ExitStack
-from typing import Any, Dict, List, Union
 from unittest import mock
 
 import pytest
@@ -16,17 +15,12 @@ from husky_directory.services.pws import PersonWebServiceClient
 from husky_directory.services.search import (
     DirectorySearchService,
 )
-from husky_directory.services.translator import (
-    ListPersonsOutputTranslator,
-    PersonOutputFilter,
-)
 
 
 class TestDirectorySearchService:
     @pytest.fixture(autouse=True)
     def configure_base(self, injector, mock_people, mock_injected):
         self.mock_people = mock_people
-        self.pws: PersonWebServiceClient = injector.get(PersonWebServiceClient)
         self.session = {}
 
         # We have to mock a lot here in order to avoid replicating
@@ -38,9 +32,9 @@ class TestDirectorySearchService:
         # TODO: This _does_ smell like too many mocks, but another
         #       refactor seems like a "down the road" thing.
         with ExitStack() as stack:
-            # Allows us to
-            stack.enter_context(mock_injected(PersonWebServiceClient, self.pws))
             stack.enter_context(mock_injected(LocalProxy, self.session))
+            self.pws = injector.get(PersonWebServiceClient)
+            stack.enter_context(mock_injected(PersonWebServiceClient, self.pws))
             self.mock_list_persons = stack.enter_context(
                 mock.patch.object(self.pws, "list_persons")
             )
@@ -85,17 +79,19 @@ class TestDirectorySearchService:
     def test_output_includes_phones(self):
         person = self.mock_people.contactable_person
         self.list_persons_output.persons = [person]
+        self.session["uwnetid"] = "foo"
         request_input = SearchDirectoryInput(name="foo")
         output = self.client.search_directory(request_input)
         contacts = output.scenarios[0].populations["employees"].people[0].phone_contacts
 
-        for field_name, val in contacts:
-            assert (
-                getattr(
-                    person.affiliations.employee.directory_listing, field_name, None
-                )
-                == val
-            ), field_name
+        assert contacts == dict(
+            phones=["2068675309 Ext. 4242", "19999674222"],
+            faxes=["+1 999 214-9864"],
+            voice_mails=["1800MYVOICE"],
+            touch_dials=["+19999499911"],
+            mobiles=["+1 999 (967)-4222", "+1 999 (967) 4999"],
+            pagers=["1234567"],
+        )
 
     @pytest.mark.parametrize(
         "person, expected_departments",
@@ -167,7 +163,7 @@ class TestDirectorySearchService:
         person = getattr(self.mock_people, person)
         self.list_persons_output.persons = [person]
         request_input = SearchDirectoryInput(
-            name="whatever", population=input_population
+            name="Lovelace", population=input_population
         )
         output = self.client.search_directory(request_input)
         assert output.scenarios, output.dict()
@@ -196,86 +192,3 @@ class TestDirectorySearchService:
         )
         output_person: Person = output.scenarios[0].populations["employees"].people[0]
         assert output_person.box_number == "351234"
-
-
-class TestPersonOutputTranslator:
-    @pytest.fixture(autouse=True)
-    def initialize(self, injector, mock_people, mock_injected):
-        self.injector = injector
-        self.mock_people = mock_people
-        self.session = {}
-
-        with mock_injected(LocalProxy, self.session):
-            yield
-
-    @property
-    def translator(self) -> ListPersonsOutputTranslator:
-        return self.injector.get(ListPersonsOutputTranslator)
-
-    @pytest.mark.parametrize("should_be_authed", (True, False))
-    def test_current_request_is_authenticated(self, should_be_authed):
-        if should_be_authed:
-            self.session["uwnetid"] = "foo"
-        assert self.translator.current_request_is_authenticated == should_be_authed
-
-    @pytest.mark.parametrize(
-        # In these parameters, the first argument must either be the name of a profile found in
-        # the 'mock_people' fixture, OR a dictionary containing the `profile` key that mentions the base
-        # profile, where all other attributes in the dict will override the default
-        "profile, allowed_populations, request_is_authenticated, expected_result",
-        [
-            # A person with no affiliations should never be displayed.
-            ("no_affiliations", ["employees", "students"], True, False),
-            # TODO: Update once test entities are supported fully
-            ("test_entity", ["employees"], False, False),
-            # Every day published employee should:
-            #   - Be visible regardless of auth
-            ("published_employee", ["employees"], False, True),
-            ("published_employee", ["employees"], True, True),
-            #   - Be included any time "employees" is an allowed population
-            ("published_employee", ["employees", "students"], False, True),
-            #   - Not be visible when only "students" are selected
-            ("published_employee", ["students"], True, False),
-            # The top-level 'whitepages_publish' should invalidate the subsequent employee record that
-            # has publish_in_directory=True.
-            (
-                {"profile": "published_employee", "whitepages_publish": False},
-                ["employees"],
-                False,
-                False,
-            ),
-            # This employee has elected not to be published, so should not be shown
-            ("unpublished_employee", ["employees"], False, False),
-            # Student affiliations should only be returned if the user is authenticated and opted to see
-            # student data
-            #   - Regardless of auth students should never be returned if user has not requested them
-            ("published_student", ["employees"], False, False),
-            ("published_student", ["employees"], True, False),
-            #   - Even if requested, without auth, student data should be returned
-            ("published_student", ["employees", "students"], False, False),
-            #   - Only if requested AND authed can student data be returned
-            ("published_student", ["students"], True, True),
-        ],
-    )
-    def test_filter_person(
-        self,
-        profile: Union[str, Dict[str, Any]],
-        allowed_populations: List[str],
-        request_is_authenticated: bool,
-        expected_result: bool,
-    ):
-        if request_is_authenticated:
-            self.session["uwnetid"] = "authuser"
-
-        if isinstance(profile, str):
-            person = getattr(self.mock_people, profile)
-        else:
-            person = getattr(self.mock_people, profile["profile"])
-            person = person.copy(update=profile)
-
-        assert (
-            self.translator.filter_person(
-                person, PersonOutputFilter(allowed_populations=allowed_populations)
-            )
-            == expected_result
-        )

--- a/tests/services/test_translator.py
+++ b/tests/services/test_translator.py
@@ -1,0 +1,48 @@
+import pytest
+from werkzeug.local import LocalProxy
+
+from husky_directory.models.enum import PopulationType
+from husky_directory.services.translator import ListPersonsOutputTranslator
+
+
+class TestPersonOutputTranslator:
+    @pytest.fixture(autouse=True)
+    def initialize(self, injector, mock_people, mock_injected):
+        self.injector = injector
+        self.mock_people = mock_people
+        self.session = {}
+
+        with mock_injected(LocalProxy, self.session):
+            yield
+
+    @property
+    def translator(self) -> ListPersonsOutputTranslator:
+        return self.injector.get(ListPersonsOutputTranslator)
+
+    def test_translate_scenario(self, generate_person):
+        pws_output = self.mock_people.as_search_output(
+            self.mock_people.contactable_person,
+            generate_person(),  # This empty person should be ignored
+        )
+
+        netid_tracker = set()
+        result = self.translator.translate_scenario(pws_output, netid_tracker)
+
+        employees = result[PopulationType.employees]
+        students = result[PopulationType.students]
+
+        assert employees.num_results == 1
+        assert students.num_results == 1
+
+        assert employees.people[0] == students.people[0]
+
+        person = employees.people[0]
+
+        # Ensure student email was overwritten by employee email
+        assert person.email == "dawg@uw.edu"
+        assert person.box_number == "351234"
+        assert person.phone_contacts.phones == ["2068675309 Ext. 4242", "19999674222"]
+        assert person.departments[0].department == "Cybertronic Engineering"
+        assert person.departments[0].title == "Junior"
+        assert person.departments[1].department == "Haute Cuisine"
+        assert person.departments[1].title == "Garde Manger"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,58 @@
+import pytest
+
+from husky_directory.util import ConstraintPredicates
+
+
+class TestConstraintPredicates:
+    def test_normalize_strings(self):
+        assert list(
+            ConstraintPredicates.normalize_strings(
+                "FOO", "fOo", 13, False, {"bAR": "baz"}
+            )
+        ) == ["foo", "foo", 13, False, {"bAR": "baz"}]
+
+    @pytest.mark.parametrize(
+        "target, value, expected",
+        [
+            ("foo", None, True),
+            ("foo", "football", True),
+            ("Foo", "fOo", True),
+            ("foo", "oof", False),
+        ],
+    )
+    def test_null_or_begins_with(self, target, value, expected):
+        assert ConstraintPredicates.null_or_begins_with(target, value) == expected
+
+    @pytest.mark.parametrize(
+        "target, value, expected",
+        [
+            ("foo", None, True),
+            ("Foo", "fOo", True),
+            ("Foo", "football", False),
+        ],
+    )
+    def test_null_or_matches(self, target, value, expected):
+        assert ConstraintPredicates.null_or_matches(target, value) == expected
+
+    @pytest.mark.parametrize(
+        "target, value, expected",
+        [
+            ("foo", None, False),
+            ("Foo", "fOo", True),
+            ("Foo", "football", False),
+        ],
+    )
+    def test_matches(self, target, value, expected):
+        assert ConstraintPredicates.matches(target, value) == expected
+
+    @pytest.mark.parametrize(
+        "target, value, expected",
+        [
+            ("fOO", "pRouDFoot", True),
+            ("foo", None, True),
+            ("foo", "oof", False),
+            ("Foo", ["FOo", "bar", "baz"], True),
+        ],
+    )
+    def test_null_or_includes(self, target, value, expected):
+        assert ConstraintPredicates.null_or_includes(target, value) == expected


### PR DESCRIPTION
Closes EDS-584

This is a bigger change than you'd expect, because the fundamental architecture of the post-request filtering was awkwardly designed (see? It's not just others' code i refactor mercilessly) — as in, it wasn't really designed, and therefore was glued together in several ways that made it difficult to visualize, trace, and update. Now all of our constraints are handled the same way by a central component, as close to the "raw" data as possible.

This fixes the problem by formalizing the post-request filtering into a single standard set of constraints, while also allowing certain queries to apply additional constraints. A constraint is basically a function that tests against the returned data from PWS, allowing us to address things like publication flags for affiliations, as well as actual tests of values (which serves to aid in the solution to EDS-584).

So: `services/query_enerator.py` is the place where changes were made to specifically address EDS-584; everything else is the iceberg.

If you want to understand constraints further, check out `husky_directory/models/common.py#RecordConstraint` — this will allow us to easily add and maintain filters based on queries, as well as application-wide filters, on the data we receive from PWS.

Another place that is useful to look is in `services/pws.py`, _particularly_ the `global_constraints` property, which defines application-wide constraints we will place on all data.

The actual test to prove EDS-584 can close is the test in `tests/blueprints/test_search_blueprint.py`: `test_get_person_non_matching_surname`.