### PR TITLE
[EDS-549]  Sort search results by last name

### DIFF
--- a/husky_directory/services/translator.py
+++ b/husky_directory/services/translator.py
@@ -100,6 +100,7 @@ class ListPersonsOutputTranslator:
 
             result = Person(
                 name=person.display_name,
+                sort_key=person.preferred_last_name or person.registered_surname,
                 phone_contacts=self._resolve_phones(employee, student),
                 **person.dict()
             )

--- a/tests/blueprints/test_search_blueprint.py
+++ b/tests/blueprints/test_search_blueprint.py
@@ -386,6 +386,37 @@ class TestSearchBlueprint(BlueprintSearchTestBase):
         assert response.status_code == 200
         assert response.json["numResults"] == expected_num_results
 
+    def test_list_people_sort(self, generate_person, random_string):
+        people = self.mock_people.as_search_output(
+            self.mock_people.published_employee.copy(
+                update={
+                    "preferred_last_name": "Zlovelace",
+                    "registered_surname": "Alovelace",
+                    "netid": random_string(),
+                }
+            ),
+            self.mock_people.published_employee.copy(
+                update={
+                    "registered_surname": "Blovelace",
+                    "netid": random_string(),
+                }
+            ),
+            self.mock_people.published_employee.copy(
+                update={
+                    "preferred_last_name": "Alovelace",
+                    "netid": random_string(),
+                }
+            ),
+        )
+        self.mock_send_request.return_value = people
+        response = self.flask_client.get("/search?name=lovelace")
+        assert response.status_code == 200
+        sort_keys = [
+            p["sortKey"]
+            for p in response.json["scenarios"][0]["populations"]["employees"]["people"]
+        ]
+        assert sort_keys == ["Alovelace", "Blovelace", "Zlovelace"]
+
     def test_get_person_vcard(self):
         """
         Tests that the blueprint returns the right result, but does not test

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,9 +58,17 @@ def app(
 
 
 @pytest.fixture
-def generate_person():
+def random_string():
+    def inner(num_chars: int = 8) -> str:
+        return "".join(random.choice(string.ascii_lowercase) for _ in range(8))
+
+    return inner
+
+
+@pytest.fixture
+def generate_person(random_string):
     def inner(**attrs: Any) -> PersonOutput:
-        random_string = "".join(random.choice(string.ascii_lowercase) for _ in range(8))
+        netid = random_string()
         default = PersonOutput(
             display_name="Ada Lovelace",
             registered_name="Ada Lovelace",
@@ -68,8 +76,8 @@ def generate_person():
             registered_first_middle_name="Ada",
             whitepages_publish=True,
             is_test_entity=False,
-            netid=random_string,
-            href=f"person/{random_string}",
+            netid=netid,
+            href=f"person/{netid}",
         )
         return default.copy(update=attrs)
 


### PR DESCRIPTION
Closes EDS-549.

- Adds a `sort_key`/`sortKey` field to the `Person` model
- Sets the `sort_key` to the preferred_last_name if it is set, otherwise the registered_surname, _otherwise_ the display name (extreme edge case)
- When exporting the `DirectoryQueryPopulationOutput` model, sort the list of `people` based on the sort key.
- Adds a test to ensure sorting
- Minor update to tests to modularize the `random_string` function into callable fixture