### PR TITLE
Productionize maintenance workflow

### DIFF
--- a/.github/scripts/install-build-scripts.sh
+++ b/.github/scripts/install-build-scripts.sh
@@ -1,0 +1,5 @@
+# These first two commands will download the scripts and source files to `~/.common-build-scripts`
+set -x
+gh auth login --with-token $GITHUB_TOKEN
+source <(curl -s https://raw.githubusercontent.com/UWIT-IAM/common-build-scripts/main/sources/github.sh)
+get_tag_archive UWIT-IAM/common-build-scripts latest $BUILD_SCRIPTS_DIR

--- a/.github/steps/README.md
+++ b/.github/steps/README.md
@@ -1,0 +1,35 @@
+# .github/steps
+
+This directory houses scripts and resources used by workflow steps. 
+
+Scripting individual steps makes it easier to maintain, test, and debug
+workflows. Wherever is practical, strive to move
+behavior into scripts, and out of actions yml files themselves.
+
+## Structure
+
+Each subdirectory in `steps` should match the name of a workflow, and any included 
+scripts should match a declared step id in the workflow. This is just to make it 
+easier to navigate. 
+
+To share scripts between workflows, it's best to put them in a common `steps/shared` 
+directory so that the intent is clear.
+
+```
++ .github
+| + steps
+| | + <workflow-name>
+| | | - <filename>
+| | + shared
+```
+
+## Capabilities
+
+These scripts are meant to be run via Github Actions, and therefore may rely on 
+environment variables, etc. provided by Actions or the workflow.
+
+
+## Constraints
+
+- Scripts cannot contain github context syntax (e.g., `${{ foo }}`); any such
+syntax will not be interpolated. 

--- a/.github/steps/scheduled-maintenance/configure-environment.sh
+++ b/.github/steps/scheduled-maintenance/configure-environment.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -x
+
+./.github/scripts/install-build-scripts.sh
+source $BUILD_SCRIPTS_DIR/sources/github-actions.sh
+POETRY_VERSION_GUIDANCE=${POETRY_VERSION_GUIDANCE:-patch}
+
+slack_notification_json="./.github/steps/scheduled-maintenance/slack-notification.json"
+slack_notification_json=$(echo `cat $slack_notification_json`)
+
+gcloud auth configure-docker
+poetry version ${POETRY_VERSION_GUIDANCE}
+new_app_version=$(poetry version -s)
+new_di_version=$(date +%Y.%-j.%-I.%-M)
+di_fingerprint=$(./scripts/get-snapshot-fingerprint.sh)
+set_ci_output workflow-json "$slack_notification_json"
+set_ci_output new-app-version "$new_app_version"
+set_ci_output new-di-version "$new_di_version"
+set_ci_output di-fingerprint "$di_fingerprint"

--- a/.github/steps/scheduled-maintenance/configure-environment.sh
+++ b/.github/steps/scheduled-maintenance/configure-environment.sh
@@ -2,17 +2,17 @@
 set -x
 
 ./.github/scripts/install-build-scripts.sh
-source $BUILD_SCRIPTS_DIR/sources/github-actions.sh
+
 POETRY_VERSION_GUIDANCE=${POETRY_VERSION_GUIDANCE:-patch}
+
+gcloud auth configure-docker
+poetry version ${POETRY_VERSION_GUIDANCE}
+poetry lock
+source ${STEP_SCRIPTS}/context-vars.src.sh
 
 slack_notification_json="./.github/steps/scheduled-maintenance/slack-notification.json"
 slack_notification_json=$(echo `cat $slack_notification_json`)
 
-gcloud auth configure-docker
-poetry version ${POETRY_VERSION_GUIDANCE}
-new_app_version=$(poetry version -s)
-new_di_version=$(date +%Y.%-j.%-I.%-M)
-di_fingerprint=$(./scripts/get-snapshot-fingerprint.sh)
 set_ci_output workflow-json "$slack_notification_json"
 set_ci_output new-app-version "$new_app_version"
 set_ci_output new-di-version "$new_di_version"

--- a/.github/steps/scheduled-maintenance/context-vars.src.sh
+++ b/.github/steps/scheduled-maintenance/context-vars.src.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+source $BUILD_SCRIPTS_DIR/sources/slack.sh
+source $BUILD_SCRIPTS_DIR/sources/github-actions.sh
+
+BASE_IMAGE=${BASE_IMAGE_REPO}
+APP_IMAGE=${APP_IMAGE_REPO}
+PR_URL_BASE=${PR_URL_BASE}
+
+new_app_version=$(poetry version -s)
+new_di_version=$(date +%Y.%-j.%-I.%-M)
+di_fingerprint=$(./scripts/get-snapshot-fingerprint.sh)
+di_img_url=https://${BASE_IMAGE}:${new_di_version}
+app_img_url=https://${APP_IMAGE}:${new_app_version}
+app_link="$(slack_link $app_img_url $new_app_version)"
+di_link="$(slack_link $di_img_url $new_di_version)"

--- a/.github/steps/scheduled-maintenance/create-build-artifact.sh
+++ b/.github/steps/scheduled-maintenance/create-build-artifact.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+source ${STEP_SCRIPTS}/context-vars.src.sh
+
+pr_number=${GITHUB_PR_NUMBER}
+pr_url=${PR_URL_BASE}/${pr_number}
+pr_link="$(slack_link $pr_url PR#${pr_number})"
+workflow_artifact="Created ${pr_link} for version ${app_link} "
+workflow_artifact+="and pushed dependency image version ${di_link}"
+
+echo "$workflow_artifact"
+set_ci_output slack-artifact "$workflow_artifact"

--- a/.github/steps/scheduled-maintenance/create-pull-request.sh
+++ b/.github/steps/scheduled-maintenance/create-pull-request.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+pr_body="Beep boop! I'm a bot, here to make sure your dependencies are up to date! "
+pr_body+="Everything looks good, I just need your approval to merge this "
+pr_body+="change in to your main branch!"
+
+source $BUILD_SCRIPTS_DIR/sources/github-actions.sh
+
+gh pr create \
+  -B main \
+  -b "${pr_body}" \
+  -r tomthorogood \
+  -r goulter \
+  -r jdiverp \
+  --fill
+
+pr_number=$(gh pr list --json number -q '.[0].number')
+
+set_ci_output pull-request-number "$pr_number"

--- a/.github/steps/scheduled-maintenance/slack-notification.json
+++ b/.github/steps/scheduled-maintenance/slack-notification.json
@@ -1,0 +1,29 @@
+{
+  "channel": "#iam-bot-sandbox",
+  "description": "UW Directory Scheduled Maintenance",
+  "status": "in progress",
+  "steps": [
+    {
+      "description": "Configure build environment",
+      "stepId": "configure",
+      "status": "succeeded"
+    },
+    {
+      "description": "Rebuild images",
+      "stepId": "rebuild-images",
+      "status": "in progress"
+    },
+    {
+      "description": "Test application image",
+      "stepId": "test-application-image"
+    },
+    {
+      "description": "Create pull request for new dependency data",
+      "stepId": "push-poetry-lock"
+    },
+    {
+      "description": "Push dependency image fingerprint",
+      "stepId": "push-di-fingerprint"
+    }
+  ]
+}

--- a/.github/steps/scheduled-maintenance/update-application-image.sh
+++ b/.github/steps/scheduled-maintenance/update-application-image.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+version=$(poetry version -s)
+
+test -z "${DEBUG}" || set -x
+image_repo=gcr.io/uwit-mci-iam/husky-directory
+fingerprint=$(./scripts/get-snapshot-fingerprint.sh)
+docker build \
+  -f docker/development-server.dockerfile \
+  --build-arg BASE_VERSION=${fingerprint} \
+  -t ${image_repo}:${version} \
+  .

--- a/.github/steps/scheduled-maintenance/update-dependency-image.sh
+++ b/.github/steps/scheduled-maintenance/update-dependency-image.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+test -z "${DEBUG}" || set -x
+image_repo=gcr.io/uwit-mci-iam/husky-directory-base
+fingerprint=$(./scripts/get-snapshot-fingerprint.sh)
+$BUILD_SCRIPTS_DIR/scripts/pull-or-build-image.sh \
+  -i $image_repo:$fingerprint \
+  -d docker/husky-directory-base.dockerfile

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,62 @@
+# Workflows
+
+The `.yml` files in this directory are used by Github Actions to run workflows.
+See [Github Actions documentation] if you want to learn more about how these work.
+
+This document will discuss the workflow intents and oddities, as needed.
+
+## scheduled-maintenance
+
+The [scheduled-maintenance] workflow runs on a weekly schedule and
+is responsible for keeping our dependencies and runtime OS patched.
+
+Notifications for this workflow are sent to the `#cloud-native-directory` 
+slack channel. 
+
+### Artifacts
+
+As a result of this workflow, the following artifacts will be created:
+
+1. A git tag of the new application version (e.g., 1.2.3)
+2. A dependency image tagged both with its sha256 fingerprint as well as the
+   pseduo-semver datetime "version" (e.g., 255.15.7, for a build that ran at 3:07pm 
+   on September 12).
+3. An application image tagged with its new patch version  (e.g., 1.2.3)
+4. A pull request that can be merged without careful review.
+
+
+### Testing
+
+You can test this workflow by pushing to the `run-scheduled-maintenance-workflow` 
+branch. When doing this, the git tag will be `0.0.0-testing`
+and the application image will have a prerelease version (1.2.2-alpha.0),
+instead of a patch version (1.2.3). This will prevent tests from having any
+lasting effects on our tag history.
+
+### FAQs
+
+> Should I approve this automatic pull request?
+
+Yes! You should! In the future, this process too will be automated. The pull request
+will not be created if the tests fail, so you should only see a PR created if 
+everything worked.
+
+> What if this workflow fails?
+
+This workflow only creates artifacts if all tests are successful. A failure
+indicates that one of the dependencies that was updated is not compatible
+with our current application. You may ignore this change and hope that 
+the next week's sync resolves the problem, or you can investigate to 
+discover the cause and remediate it. If your investigations lead you to 
+believe that a certain dependency should not be updated until further
+notice, keep reading...
+
+> What if I don't want certain packages to update?
+
+You can pin a specific version in `pyproject.toml`. If the version
+guidance is exact, the `poetry lock` command will not find
+any new updates (e.g., change `^1.2` to `1.2.3`).
+
+
+[Github Actions documentation]: https://... 
+[scheduled-maintenance]: https://...

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -1,14 +1,13 @@
 name: Weekly uw-husky-directory scheduled maintenance
 
 on:
-  schedule:
-    - cron: '0 4 * * 1'  # Run at 4am (UTC) every Monday.
+# schedule:
+#   - cron: '0 4 * * 1'  # Run at 4am (UTC) every Monday.
   push:
     # This supports the ability to force push to run for testing purposes,
     # or if you want to force a rebuild for any reason! Go for it!
     branches:
       - run-scheduled-maintenance-workflow
-  workflow_dispatch:
 
 env:
   SLACK_BOT_TOKEN: ${{ secrets.ACTIONS_SLACK_BOT_TOKEN }}
@@ -24,17 +23,19 @@ jobs:
   scheduled-maintenance:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v2
 
       - if: github.event_name != 'schedule'
         run: echo "POETRY_VERSION_GUIDANCE=prerelease" >> $GITHUB_ENV
+        name: Update version guidance
 
       - name: Bootstrap Google Cloud
         with:
           project_id: ${{ secrets.IAM_GCR_REPO }}
           service_account_key: ${{ secrets.GCR_TOKEN }}
           export_default_credentials: true
-        uses: google-github-actions/setup-gcloud@master
+          credentials_file_path: ${{ github.workspace }}/gcloud-credentials.json
+        uses: google-github-actions/setup-gcloud@v0.2.1
 
       - name: Install Poetry
         uses: abatilo/actions-poetry@v2.1.0
@@ -48,6 +49,7 @@ jobs:
           command: create-canvas
           json: ${{ steps.configure.outputs.workflow-json }}
         id: create-canvas
+        name: Create slack notification
 
       - run: |
           echo "SLACK_CANVAS_ID=${{ steps.create-canvas.outputs.canvas-id }}" >> $GITHUB_ENV
@@ -57,10 +59,19 @@ jobs:
 
       - uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.1
         with:
+          command: add-artifact
+          description: >
+            <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            | workflow execution> triggered by '${{ github.event_name }}' event.
+        name: Add execution information to slack
+
+      - uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.1
+        with:
           command: update-workflow
           step-id: ${{ env.ACTIVE_STEP }}, ${{ env.NEXT_STEP }}
           step-status: succeeded, in progress
         if: steps.create-canvas.outputs.canvas-id
+        name: Update workflow status
       - run: |
           echo "ACTIVE_STEP=$NEXT_STEP" >> $GITHUB_ENV
           echo "NEXT_STEP=test-application-image" >> $GITHUB_ENV
@@ -69,6 +80,7 @@ jobs:
       - run: |
           $STEP_SCRIPTS/update-dependency-image.sh
           $STEP_SCRIPTS/update-application-image.sh
+        name: Build new images
 
       - uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.1
         with:
@@ -76,15 +88,17 @@ jobs:
           step-id: ${{ env.ACTIVE_STEP }}, ${{ env.NEXT_STEP }}
           step-status: succeeded, in progress
         if: steps.create-canvas.outputs.canvas-id
-        name: Advance workflow to next step
+        name: Update workflow status
 
       - run: |
           echo "ACTIVE_STEP=$NEXT_STEP" >> $GITHUB_ENV
           echo "NEXT_STEP=push-poetry-lock" >> $GITHUB_ENV
+        name: Advance workflow to next step
 
       - run: ./scripts/run-image-tests.sh -i $APP_IMAGE_REPO:$new_version --headless
         env:
           new_version: ${{ steps.configure.outputs.new-app-version }}
+        name: Run tests
 
       - uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.1
         with:
@@ -92,57 +106,38 @@ jobs:
           step-id: ${{ env.ACTIVE_STEP }}, ${{ env.NEXT_STEP }}
           step-status: succeeded, in progress
         if: steps.create-canvas.outputs.canvas-id
-        name: Advance workflow to next step
+        name: Update workflow status
 
       - run: |
           echo "ACTIVE_STEP=$NEXT_STEP" >> $GITHUB_ENV
           echo "NEXT_STEP=push-di-fingerprint" >> $GITHUB_ENV
+        name: Advance workflow to next step
 
-      - uses: EndBug/add-and-commit@v7 # You can change this to use a specific version
+      - name: Add & Commit
+        uses: EndBug/add-and-commit@v7.2.1
         env:
-          tag: ${{ github.event_name == 'schedule' && steps.configure.outputs.new_app_version || '0.0.0-testing --force' }}
+          git_tag: ${{ github.event_name == 'schedule' && steps.configure.outputs.new-app-version || '0.0.0-testing --force'}}
         with:
           add: 'pyproject.toml poetry.lock'
-          branch: scheduled-maintenance
           default_author: github_actions
           pull_strategy: 'NO-PULL'
-          push: true
-          tag: ${{ env.tag }}
+          tag: ${{ env.git_tag }}
 
       - name: create pull request
-        uses: peter-evans/create-pull-request@v3.10.0
-        with:
-          branch: scheduled-maintenance
-          base: main
-          title: Scheduled dependency updates (${{ steps.configure.outputs.new-di-version }}
-          body: |
-            Beep boop! I'm a bot, here to make sure your dependencies are up to date!
-            Everything looks good, I just need your approval to merge this
-            change in to your main branch!
+        run: ${STEP_SCRIPTS}/create-pull-request.sh
+        id: create-pull-request
 
-            > What if I don't want to do this?
-
-            No problem! Just close this pull request. I'll bug you again next week.
-          assigness: tomthorogood, goulter, jdiverp
+      - run: ${STEP_SCRIPTS}/create-build-artifact.sh
+        id: create-artifact
+        env:
+          GITHUB_PR_NUMBER: ${{ steps.create-pull-request.outputs.pull-request-number }}
 
       - uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.1
         if: steps.create-canvas.outputs.canvas-id
-        env:
-          di_version: ${{ steps.configure.outputs.new-di-version }}
-          app_version: ${{ steps.configure.outputs.new-app-version }}
-          pr_num: ${{ steps.create-pull-request.outputs.pull-request-number }}
-          pr_url: ${{ env.PR_URL_BASE }}/${{ steps.create-pull-request.outputs.pull-request-number }}
-          di_url: https://${{ env.BASE_IMAGE_REPO }}:${{ steps.configure.outputs.new-di-version }}
-          app_url: https://${{ env.APP_IMAGE_REPO }}:${{ steps.configure.outputs.new-app-version }}
-          pr_link: <${{ env.pr_url }} | PR#${{ env.pr_num }}>
-          di_link: <${{ env.di_url }} | ${{ env.di_version }}>
-          app_link: <${{ env.app_url }} | ${{ env.app_version }}>
         with:
           command: add-artifact
-          description: |
-            * Created ${{ env.pr_link }} for version ${{ env.app_link }}
-
-            * Pushed dependency image version ${{ env.di_link }}
+          description: ${{ steps.create-artifact.outputs.slack-artifact }}
+        name: Add notification artifact
 
       - uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.1
         with:
@@ -150,7 +145,7 @@ jobs:
           step-id: ${{ env.ACTIVE_STEP }}, ${{ env.NEXT_STEP }}
           step-status: succeeded, in progress
         if: steps.create-canvas.outputs.canvas-id
-        name: Advance workflow to next step
+        name: Update workflow status
 
       - run: |
           echo "ACTIVE_STEP=$NEXT_STEP" >> $GITHUB_ENV
@@ -158,6 +153,7 @@ jobs:
           docker push $BASE_IMAGE_REPO:$fingerprint
           docker push $BASE_IMAGE_REPO:$new_di_version
           docker push $APP_IMAGE_REPO:$new_app_version
+        name: Push images
         env:
           fingerprint: ${{ steps.configure.outputs.di-fingerprint }}
           new_di_version: ${{ steps.configure.outputs.new-di-version }}
@@ -168,6 +164,7 @@ jobs:
           step-id: ${{ env.ACTIVE_STEP }}
           step-status: succeeded
         if: steps.create-canvas.outputs.canvas-id
+        name: Update workflow status
 
       # Everything after this is the epilogue that cleans up the workflow
       - if: failure() && steps.create-canvas.outputs.canvas-id
@@ -177,12 +174,14 @@ jobs:
           step-status: failed
           workflow-status: failed
         uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.1
+        name: Mark workflow as failed
 
       - with:
           command: update-workflow
           workflow-status: succeeded
         uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.1
         if: success() && steps.create-canvas.outputs.canvas-id
+        name: Mark workflow as succeeded
 
       - if: always() && steps.create-canvas.outputs.canvas-id
         with:
@@ -190,8 +189,10 @@ jobs:
           step-id: '*'
           step-status: succeeded
         uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.1
+        name: Clean up successful steps
 
       - if: always() && steps.create-canvas.outputs.canvas-id
         with:
           command: finalize-workflow
         uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.1
+        name: Finalize workflow

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -2,119 +2,196 @@ name: Weekly uw-husky-directory scheduled maintenance
 
 on:
   schedule:
-    - cron: '0 4 * * 1'  # Run at 4am every Monday.
+    - cron: '0 4 * * 1'  # Run at 4am (UTC) every Monday.
   push:
     # This supports the ability to force push to run for testing purposes,
     # or if you want to force a rebuild for any reason! Go for it!
     branches:
       - run-scheduled-maintenance-workflow
+  workflow_dispatch:
 
 env:
   SLACK_BOT_TOKEN: ${{ secrets.ACTIONS_SLACK_BOT_TOKEN }}
-  SLACK_CANVAS_ID: "${{ github.run_id }}.${{ github.run_number }}"
   BASE_IMAGE_REPO: gcr.io/${{ secrets.IAM_GCR_REPO }}/husky-directory-base
-  SLACK_CHANNEL: '#iam-bots'
+  APP_IMAGE_REPO: gcr.io/${{ secrets.IAM_GCR_REPO }}/husky-directory
+  SLACK_CHANNEL: '#cloud-native-directory'
+  STEP_SCRIPTS: ./.github/steps/scheduled-maintenance
+  BUILD_SCRIPTS_DIR: /tmp/build-scripts
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  PR_URL_BASE: https://github.com/${{ github.repository }}/pull
 
 jobs:
-  configure-workflow:
+  scheduled-maintenance:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
-      - with:
+
+      - if: github.event_name != 'schedule'
+        run: echo "POETRY_VERSION_GUIDANCE=prerelease" >> $GITHUB_ENV
+
+      - name: Bootstrap Google Cloud
+        with:
           project_id: ${{ secrets.IAM_GCR_REPO }}
           service_account_key: ${{ secrets.GCR_TOKEN }}
           export_default_credentials: true
         uses: google-github-actions/setup-gcloud@master
-      - name: Create SEMVER-like version string from the date and time
-        run: echo "VERSION=$(date +%Y.%-j.%-I.%-M)" >> $GITHUB_ENV
-      - name: Initialize workflow canvas
+
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v2.1.0
+
+      - name: Configure build
+        run: $STEP_SCRIPTS/configure-environment.sh
+        id: configure
+
+      - uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.1
         with:
           command: create-canvas
-          channel: ${{ env.SLACK_CHANNEL }}
-          description: ${{ github.workflow }}
-        uses: UWIT-IAM/actions/update-slack-workflow-canvas@release
-      - with:
-          command: create-step
-          step-id: rebuild-base-image
-          workflow-status: in progress
-          description: >
-            Re-build <https://${{ env.BASE_IMAGE_REPO }} | husky-directory-base>
-        uses: UWIT-IAM/actions/update-slack-workflow-canvas@release
-      - with:
-          command: create-step
-          step-id: push-base-image
-          description: >
-            Push version
-            <https://${{ env.BASE_IMAGE_REPO }}:${{ env.VERSION }} | ${{ env.VERSION }}>
-        uses: UWIT-IAM/actions/update-slack-workflow-canvas@release
-      - with:
-          command: add-artifact
-          description: >
-            *Event*:
-            <https://www.github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-            | ${{ github.event_name }}>
-        uses: UWIT-IAM/actions/update-slack-workflow-canvas@release
-      - with:
-          project_id: ${{ secrets.IAM_GCR_REPO }}
-          service_account_key: ${{ secrets.GCR_TOKEN }}
-          export_default_credentials: true
-        uses: google-github-actions/setup-gcloud@master
-      - with:
-          command: update-workflow
-          step-id: rebuild-base-image
-          step-status: in progress
-        uses: UWIT-IAM/actions/update-slack-workflow-canvas@release
-      - name: Rebuild husky-directory-base
-        env:
-          # Despite my best efforts, this cannot currently be
-          # factored into a common action. See # https://github.com/actions/runner/issues/991
-          FINGERPRINT: ${{ hashFiles('poetry.lock', 'docker/husky-directory-base.dockerfile') }}
-        run: |
-          gcloud auth configure-docker
-          docker build --build-arg FINGERPRINT -f docker/husky-directory-base.dockerfile -t base .
-      - with:
-          command: update-workflow
-          step-id: rebuild-base-image
-          step-status: succeeded
-        uses: UWIT-IAM/actions/update-slack-workflow-canvas@release
-      - with:
-          command: update-workflow
-          step-id: push-base-image
-          step-status: in progress
-        uses: UWIT-IAM/actions/update-slack-workflow-canvas@release
+          json: ${{ steps.configure.outputs.workflow-json }}
+        id: create-canvas
+
       - run: |
-          docker tag base ${{ env.BASE_IMAGE_REPO }}:$VERSION
-          docker tag base ${{ env.BASE_IMAGE_REPO }}:edge
-          docker push ${{ env.BASE_IMAGE_REPO }}:$VERSION
-          docker push ${{ env.BASE_IMAGE_REPO }}:edge
-      - with:
+          echo "SLACK_CANVAS_ID=${{ steps.create-canvas.outputs.canvas-id }}" >> $GITHUB_ENV
+          echo "ACTIVE_STEP=configure" >> $GITHUB_ENV
+          echo "NEXT_STEP=rebuild-images" >> $GITHUB_ENV
+        name: Export slack notification state variables
+
+      - uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.1
+        with:
           command: update-workflow
-          step-id: push-base-image
-          step-status: failed
-        if: failure()
-        uses: UWIT-IAM/actions/update-slack-workflow-canvas@release
-      - with:
+          step-id: ${{ env.ACTIVE_STEP }}, ${{ env.NEXT_STEP }}
+          step-status: succeeded, in progress
+        if: steps.create-canvas.outputs.canvas-id
+      - run: |
+          echo "ACTIVE_STEP=$NEXT_STEP" >> $GITHUB_ENV
+          echo "NEXT_STEP=test-application-image" >> $GITHUB_ENV
+        name: Advance workflow to next step
+
+      - run: |
+          $STEP_SCRIPTS/update-dependency-image.sh
+          $STEP_SCRIPTS/update-application-image.sh
+
+      - uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.1
+        with:
           command: update-workflow
-          step-id: push-base-image
+          step-id: ${{ env.ACTIVE_STEP }}, ${{ env.NEXT_STEP }}
+          step-status: succeeded, in progress
+        if: steps.create-canvas.outputs.canvas-id
+        name: Advance workflow to next step
+
+      - run: |
+          echo "ACTIVE_STEP=$NEXT_STEP" >> $GITHUB_ENV
+          echo "NEXT_STEP=push-poetry-lock" >> $GITHUB_ENV
+
+      - run: ./scripts/run-image-tests.sh -i $APP_IMAGE_REPO:$new_version --headless
+        env:
+          new_version: ${{ steps.configure.outputs.new-app-version }}
+
+      - uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.1
+        with:
+          command: update-workflow
+          step-id: ${{ env.ACTIVE_STEP }}, ${{ env.NEXT_STEP }}
+          step-status: succeeded, in progress
+        if: steps.create-canvas.outputs.canvas-id
+        name: Advance workflow to next step
+
+      - run: |
+          echo "ACTIVE_STEP=$NEXT_STEP" >> $GITHUB_ENV
+          echo "NEXT_STEP=push-di-fingerprint" >> $GITHUB_ENV
+
+      - uses: EndBug/add-and-commit@v7 # You can change this to use a specific version
+        env:
+          tag: ${{ github.event_name == 'schedule' && steps.configure.outputs.new_app_version || '0.0.0-testing --force' }}
+        with:
+          add: 'pyproject.toml poetry.lock'
+          branch: scheduled-maintenance
+          default_author: github_actions
+          pull_strategy: 'NO-PULL'
+          push: true
+          tag: ${{ env.tag }}
+
+      - name: create pull request
+        uses: peter-evans/create-pull-request@v3.10.0
+        with:
+          branch: scheduled-maintenance
+          base: main
+          title: Scheduled dependency updates (${{ steps.configure.outputs.new-di-version }}
+          body: |
+            Beep boop! I'm a bot, here to make sure your dependencies are up to date!
+            Everything looks good, I just need your approval to merge this
+            change in to your main branch!
+
+            > What if I don't want to do this?
+
+            No problem! Just close this pull request. I'll bug you again next week.
+          assigness: tomthorogood, goulter, jdiverp
+
+      - uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.1
+        if: steps.create-canvas.outputs.canvas-id
+        env:
+          di_version: ${{ steps.configure.outputs.new-di-version }}
+          app_version: ${{ steps.configure.outputs.new-app-version }}
+          pr_num: ${{ steps.create-pull-request.outputs.pull-request-number }}
+          pr_url: ${{ env.PR_URL_BASE }}/${{ steps.create-pull-request.outputs.pull-request-number }}
+          di_url: https://${{ env.BASE_IMAGE_REPO }}:${{ steps.configure.outputs.new-di-version }}
+          app_url: https://${{ env.APP_IMAGE_REPO }}:${{ steps.configure.outputs.new-app-version }}
+          pr_link: <${{ env.pr_url }} | PR#${{ env.pr_num }}>
+          di_link: <${{ env.di_url }} | ${{ env.di_version }}>
+          app_link: <${{ env.app_url }} | ${{ env.app_version }}>
+        with:
+          command: add-artifact
+          description: |
+            * Created ${{ env.pr_link }} for version ${{ env.app_link }}
+
+            * Pushed dependency image version ${{ env.di_link }}
+
+      - uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.1
+        with:
+          command: update-workflow
+          step-id: ${{ env.ACTIVE_STEP }}, ${{ env.NEXT_STEP }}
+          step-status: succeeded, in progress
+        if: steps.create-canvas.outputs.canvas-id
+        name: Advance workflow to next step
+
+      - run: |
+          echo "ACTIVE_STEP=$NEXT_STEP" >> $GITHUB_ENV
+          docker tag $BASE_IMAGE_REPO:$fingerprint $BASE_IMAGE_REPO:$new_di_version
+          docker push $BASE_IMAGE_REPO:$fingerprint
+          docker push $BASE_IMAGE_REPO:$new_di_version
+          docker push $APP_IMAGE_REPO:$new_app_version
+        env:
+          fingerprint: ${{ steps.configure.outputs.di-fingerprint }}
+          new_di_version: ${{ steps.configure.outputs.new-di-version }}
+          new_app_version: ${{ steps.configure.outputs.new-app-version }}
+      - uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.1
+        with:
+          command: update-workflow
+          step-id: ${{ env.ACTIVE_STEP }}
           step-status: succeeded
-        if: success()
-        uses: UWIT-IAM/actions/update-slack-workflow-canvas@release
-      - with:
-          project_id: ${{ secrets.IAM_GCR_REPO }}
-          service_account_key: ${{ secrets.GCR_TOKEN }}
-          export_default_credentials: true
-        uses: google-github-actions/setup-gcloud@master
+        if: steps.create-canvas.outputs.canvas-id
+
+      # Everything after this is the epilogue that cleans up the workflow
+      - if: failure() && steps.create-canvas.outputs.canvas-id
+        with:
+          command: update-workflow
+          step-id: ${{ env.ACTIVE_STEP }}
+          step-status: failed
+          workflow-status: failed
+        uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.1
+
       - with:
           command: update-workflow
           workflow-status: succeeded
-        if: success()
-        uses: UWIT-IAM/actions/update-slack-workflow-canvas@release
-      - with:
-          command: update-workflow
-          workflow-status: failed
-        if: failure()
-        uses: UWIT-IAM/actions/update-slack-workflow-canvas@release
-      - with:
+        uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.1
+        if: success() && steps.create-canvas.outputs.canvas-id
+
+      - if: always() && steps.create-canvas.outputs.canvas-id
+        with:
+          command: remove-step
+          step-id: '*'
+          step-status: succeeded
+        uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.1
+
+      - if: always() && steps.create-canvas.outputs.canvas-id
+        with:
           command: finalize-workflow
-        if: always()
-        uses: UWIT-IAM/actions/update-slack-workflow-canvas@release
+        uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.1

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+gcloud-credentials.json
 .idea
 node_modules
 .DS_STORE

--- a/scripts/get-snapshot-fingerprint.sh
+++ b/scripts/get-snapshot-fingerprint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Generates the sha256 fingerprint of the current
+# dependency image based on the declared lock files.
+source $BUILD_SCRIPTS_DIR/sources/fingerprints.sh
+image_name='husky-directory-base'
+
+lock_files=(
+  pyproject.toml
+  poetry.lock
+  ./docker/${image_name}.dockerfile
+)
+
+echo $(calculate_paths_fingerprint ${lock_files[@]})

--- a/scripts/run-image-tests.sh
+++ b/scripts/run-image-tests.sh
@@ -3,6 +3,8 @@
 # uw-husky-directory-local)
 set -e
 
+DOCKER_RUN_ARGS=
+
 while (( $# ))
 do
   case "$1" in
@@ -10,6 +12,9 @@ do
     -i|--image-name)
       shift
       IMAGE_NAME=$1
+      ;;
+    --headless)
+      HEADLESS=1
       ;;
     # (Optional) arguments to pass to pytest; note that these will override
     # default arguments, including the testing directory.
@@ -28,6 +33,8 @@ do
   shift
 done
 
+test -n "${HEADLESS}" || DOCKER_RUN_ARGS+="-it "
+
 IMAGE_NAME="${IMAGE_NAME:-uw-husky-directory-local}"
 DEFAULT_PYTEST_ARGS="/tests --cov=/app/husky_directory --cov-fail-under=95"
 PYTEST_ARGS=${PYTEST_ARGS:-$DEFAULT_PYTEST_ARGS}
@@ -39,4 +46,4 @@ then
 fi
 
 set -x
-docker run -it "${IMAGE_NAME}" pytest ${PYTEST_ARGS}
+docker run ${DOCKER_RUN_ARGS} "${IMAGE_NAME}" pytest ${PYTEST_ARGS}


### PR DESCRIPTION
This updates the `scheduled-maintenance` workflow to:

1. Actually update dependencies
2. Test the application against those dependency updates
3. Create a PR (which _for now_ requires human approval) to patch the application version along with any updated dependencies.
4. Factor complex logic out of the yml and into bash scripts for easier testing and debugging
5. Use the new [common build scripts](https://github.com/uwit-iam/common-build-scripts) library to centralize some logic shared with identity.uw.
6. Push the new dependency image for faster builds in the future for the same dependency snapshot.
7. Push the new application image (without a deployment tag) so that it can be tested by others if desired.

This adds a negligible, optional amount of weekly overhead for devs to approve the created pull request. Ignoring this action is fine, the next week will update the same PR with any additional dependency updates.

The slack notification looks like this upon completion:

![Screen Shot 2021-08-13 at 4 31 46 PM](https://user-images.githubusercontent.com/1092941/129427212-b8e375ea-a6ac-47cc-903c-2cb67ba6b752.png)

Note that this **does not deploy any changes**; those changes won't be deployed until the artifact PR is merged.
