### PR TITLE
[Possible fix for EDS-592] Ensure the user's original host url propagates through the SAML redirection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-husky-directory"
-version = "0.2.0"
+version = "0.2.1"
 description = "An updated version of the UW Directory"
 authors = ["Thomas Thorogood <goodtom@uw.edu>"]
 license = "MIT"


### PR DESCRIPTION
I am going to test this in dev by adding an alternate URL like we have for prod, and ensuring that both work as expected.