### PR TITLE
Productionize release workflow

### DIFF
--- a/.github/steps/deploy/canvas.json
+++ b/.github/steps/deploy/canvas.json
@@ -1,0 +1,20 @@
+{
+  "description": "${{ qualifier }} Deploy husky-directory version '${{ version }}' to ${{ stage }}.",
+  "channel": "${{ slack_channel }}",
+  "steps": [
+    {
+      "stepId": "configure-deployment",
+      "description": "Configure deployment",
+      "status": "succeeded"
+    },
+    {
+      "stepId": "deploy",
+      "description": "Deploy version ${{ version }} to ${{ stage }}",
+      "status": "in progress"
+    },
+    {
+      "stepId": "validate-deployment",
+      "description": "Test deployed ${{ stage }} instance"
+    }
+  ]
+}

--- a/.github/steps/deploy/configure-canvas.sh
+++ b/.github/steps/deploy/configure-canvas.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+source ${BUILD_SCRIPTS_DIR}/sources/github-actions.sh
+
+canvas=$(${STEP_SCRIPTS}/get_slack_notification.sh \
+  -b canvas \
+  -v "$target_version" \
+  -s "$target_cluster" \
+  -q "${deployment_qualifier}" \
+  -c "#iam-bot-sandbox")  # TODO
+
+set_ci_output slack-canvas "$(echo $canvas)"
+echo "Slack canvas json: $canvas"
+
+context_artifact=$(${STEP_SCRIPTS}/get_slack_notification.sh \
+  -b context_artifact \
+  -v "$target_version" \
+  -s "$target_cluster" \
+  -q "${deployment_qualifier}")
+
+set_ci_output context-artifact "$(echo $context_artifact)"
+echo "Context artifact: $context_artifact"
+
+set -e
+test -n "$canvas"
+test -n "$context_artifact"

--- a/.github/steps/deploy/deploy.sh
+++ b/.github/steps/deploy/deploy.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+args="-t ${target_cluster} "
+
+test -n "${target_version}" && args+="--version ${target_version} "
+test -n "${rfc_number}" && args+="-r ${rfc_number} "
+test "${DRY_RUN}" = 'true' && args+="-x "
+command="./scripts/deploy.sh $args"
+echo $command
+eval $command

--- a/.github/steps/deploy/get_slack_notification.sh
+++ b/.github/steps/deploy/get_slack_notification.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+source $BUILD_SCRIPTS_DIR/sources/slack.sh
+BUILD_SCRIPTS_DIR=${BUILD_SCRIPTS_DIR:-/tmp/build-scripts}
+ACTOR=${GITHUB_ACTOR}
+SLACK_CHANNEL='#cloud-native-directory'
+
+github_workspace=${GITHUB_WORKSPACE:-.}
+step_scripts=${github_workspace}/.github/steps/deploy
+
+function print_help {
+   cat <<EOF
+   Use: get_slack_notification.sh [--debug --help]
+   Options:
+   -b, --block      The notification block to get. (default: canvas)
+   -v, --version    The version being deployed (e.g., 1.2.3)
+   -s, --stage      The stage being deployed to (e.g., dev)
+   -q, --qualifier  An optional qualifier for the deployment (e.g., 'DRY-RUN', 'RFC-1234')
+                    REQUIRED if deploying to prod.
+   -a, --actor      An optional actor for the deployment; REQUIRED if deploying to prod.
+                    (e.g., '@husky')
+   -c, --channel    The slack channel to send notifications to
+   -h, --help      Show this message and exit
+   -g, --debug     Show commands as they are executing
+EOF
+}
+
+BLOCK=canvas
+
+while (( $# ))
+do
+  case $1 in
+    --block|-b)
+      shift
+      BLOCK="$1"
+      ;;
+    --version|-v)
+      shift
+      VERSION="$1"
+      ;;
+    --stage|-s)
+      shift
+      STAGE="$1"
+      ;;
+    --actor|-a)
+      shift
+      ACTOR="$1"
+      ;;
+    --qualifier|-q)
+      shift
+      QUALIFIER="$1"
+      ;;
+    --channel|-c)
+      shift
+      SLACK_CHANNEL="$1"
+      ;;
+    --help|-h)
+      print_help
+      exit 0
+      ;;
+    --debug|-g)
+      set -x
+      ;;
+    *)
+      echo "Invalid Option: $1"
+      print_help
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+function replace_template {
+  echo "$1" | sed "s|\${{ $2 }}|$3|g"
+}
+
+function build_canvas {
+  # The echo/cat construct reduces the output to a single
+  # line, making it easier to pass around and work with.
+  template="$(echo $(cat ${step_scripts}/canvas.json))"
+  template=$(replace_template "$template" stage $STAGE)
+  template=$(replace_template "$template" version $VERSION)
+  template=$(replace_template "$template" qualifier $QUALIFIER)
+  template=$(replace_template "$template" slack_channel $SLACK_CHANNEL)
+  echo "$template"
+}
+
+function build_context_artifact {
+  actor_link=$(slack_link "https://github.com/$ACTOR" "@${ACTOR}")
+  execution_link=$(slack_link "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" execution)
+  echo "Triggered by ${GITHUB_EVENT_NAME} from $actor_link ($execution_link) on $(date)"
+}
+
+function_name="build_${BLOCK}"
+$function_name

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,73 @@
+on:
+  push:
+    branches:
+      - main
+      - dry-run-create-release
+    paths-ignore:
+      - '*.md'
+
+env:
+  BUILD_SCRIPTS_DIR: /tmp/build-scripts
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-version.outputs.version }}
+    strategy:
+      max-parallel: 1
+    steps:
+      - uses: actions/checkout@v2
+      - run: ${{ github.workspace }}/.github/scripts/install-build-scripts.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        name: Install common-build-scripts to ${{ env.BUILD_SCRIPTS_DIR }}
+      - name: Python Poetry Action
+        uses: abatilo/actions-poetry@v2.1.0
+      - uses: google-github-actions/setup-gcloud@v0.2.1
+        with:
+          project_id: ${{ secrets.IAM_GCR_REPO }}
+          service_account_key: ${{ secrets.GCR_TOKEN }}
+          export_default_credentials: true
+          credentials_file_path: /tmp/gcloud.json
+        name: Bootstrap gcloud
+      - run: gcloud auth configure-docker gcr.io
+      - run: echo ::set-output name=version::$(poetry version -s)
+        id: get-version
+        name: Get merged version
+      - run: ./scripts/pre-push.sh --headless --no-commit
+        name: Validate build
+      - name: Actions Ecosystem Action Get Merged Pull Request
+        uses: actions-ecosystem/action-get-merged-pull-request@v1.0.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        id: pr
+      - name: Push release tag
+        env:
+          pr_image: gcr.io/${{ secrets.IAM_GCR_REPO }}/husky-directory:pull-request-${{ steps.pr.outputs.number }}
+          release_image: gcr.io/${{ secrets.IAM_GCR_REPO }}/husky-directory:${{ steps.get-version.outputs.version }}
+          # When using the dry-run branch, there is no PR to draw from, so we hard-code
+          # a known-good image.
+          testing_image: gcr.io/${{ secrets.IAM_GCR_REPO }}/husky-directory:1.0.1
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]
+          then
+            docker pull $pr_image
+          else
+            docker pull $testing_image
+            docker tag $testing_image $pr_image
+          fi
+          docker tag $pr_image $release_image
+          if [[ '${{ github.ref }}' == 'refs/heads/main' ]]
+          then
+            docker push $release_image
+          else
+            echo "Not pushing $release_image in dry-run mode."
+          fi
+      - name: Create release ${{ steps.get-version.outputs.version }}
+        uses: ncipollo/release-action@v1
+        with:
+          # Use PAT so that the release will trigger the deployment workflow.
+          token: ${{ secrets.ACTIONS_PAT }}
+          tag: ${{ steps.get-version.outputs.version }}
+        if: github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,160 @@
+on:
+  push:
+    branches:
+      - dry-run-deploy
+  release:
+  workflow_dispatch:
+    inputs:
+      cluster:
+        description: cluster. Choose from dev/eval/prod.
+        default: eval
+        required: true
+      rfc:
+        description: >
+          rfc. The RFC number (e.g., '0724') associated with this
+          deployment. Required when deploying to prod.
+      version:
+        description: >
+          version. The version to deploy (e.g., '1.2.3'). If not provided,
+          the most recent release candidate will be used (eval will source from dev,
+          prod will source from eval).
+
+env:
+  BUILD_SCRIPTS_DIR: /tmp/build-scripts
+  SLACK_BOT_TOKEN: ${{ secrets.ACTIONS_SLACK_BOT_TOKEN }}
+  DRY_RUN: false
+  STEP_SCRIPTS: ${{ github.workspace }}/.github/steps/deploy
+  target_cluster: dev
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+    steps:
+      - uses: actions/checkout@v2
+      - run: ${{ github.workspace }}/.github/scripts/install-build-scripts.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        name: Install common-build-scripts
+      - uses: google-github-actions/setup-gcloud@v0.2.0
+        with:
+          project_id: ${{ secrets.GCR_REPO }}
+          service_account_key: ${{ secrets.GCR_TOKEN }}
+          export_default_credentials: true
+        name: Bootstrap gcloud
+      # When pushing from a merge to main, we'll always deploy the latest
+      # created release to dev.
+      - if: github.event_name == 'release'
+        run: echo "target_version=$(basename $GITHUB_REF)" >> $GITHUB_ENV
+        name: Configure new release deployment
+
+      # When performing an automated dry run from a push, we will be running using
+      # the basic default command of: ./deploy-sh --dry-run --target-cluster dev
+      - if: github.event_name == 'push' && github.ref == 'refs/heads/dry-run-deploy'
+        run: |
+          echo 'DRY_RUN=true' >> $GITHUB_ENV
+          echo 'deployment_qualifier=[DRY-RUN]' >> $GITHUB_ENV
+        name: Configure dry run deployment
+
+      # When pushing from the Github UI, we will fill in the values
+      # provided by the user.
+      - if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo "DRY_RUN=${{ github.event.inputs.dry-run }}" >> $GITHUB_ENV
+          echo "target_cluster=${{ github.event.inputs.cluster }}" >> $GITHUB_ENV
+          echo "target_version=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+          echo "rfc_number=${{ github.event.inputs.rfc }}" >> $GITHUB_ENV
+          echo "deployment_qualifier=[RFC-${{ github.event.inputs.rfc }}]" >> $GITHUB_ENV
+        id: configure-env
+        name: Configure manual deployment
+
+      - name: Fetch the promotion version if no version is provided
+        run:  |
+          ./scripts/deploy.sh --configure-only \
+            -t "${target_cluster}" \
+            -v "${target_version}" \
+            -r "${rfc_number}"
+        id: configure-promotion
+        if: '! env.target_version'
+
+      - name: Update env with promotion version
+        run: |
+          source ${BUILD_SCRIPTS_DIR}/sources/github-actions.sh
+          set_env target_version '${{ steps.configure-promotion.outputs.target-version }}'
+        if: '! env.target_version'
+
+      - name: Configure slack notification canvas
+        id: configure-canvas
+        run: ${STEP_SCRIPTS}/configure-canvas.sh
+
+      - uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.4
+        with:
+          json: ${{ steps.configure-canvas.outputs.slack-canvas }}
+          command: create-canvas
+        id: create-canvas
+        name: Create slack notification canvas
+
+      - run: |
+          echo "SLACK_CANVAS_ID=${{ steps.create-canvas.outputs.canvas-id }}" >> $GITHUB_ENV
+          echo "CURRENT_STEP=deploy" >> $GITHUB_ENV
+          echo "NEXT_STEP=validate-deployment" >> $GITHUB_ENV
+        name: Set up slack notification env
+
+      - uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.4
+        with:
+          command: add-artifact
+          description: ${{ steps.configure-canvas.outputs.context-artifact }}
+        name: Add context artifact to slack
+
+      - run: ${STEP_SCRIPTS}/deploy.sh
+        id: deploy
+        name: Deploy version ${{ env.target_version }}
+
+      - uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.4
+        with:
+          command: update-workflow
+          step-id: ${{ env.CURRENT_STEP }}, ${{ env.NEXT_STEP }}
+          step-status: succeeded, in progress
+        name: Update canvas and progress to ${{ env.NEXT_STEP }}
+      - run: |
+          echo "CURRENT_STEP=$NEXT_STEP" >> $GITHUB_ENV
+          echo "NEXT_STEP=" >> $GITHUB_ENV
+        name: Update canvas steps in env
+
+      - uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.4
+        with:
+          command: update-workflow
+          step-id: ${{ env.CURRENT_STEP }}
+          step-status: succeeded
+        name: Mark step as successful
+
+      - if: failure() && steps.create-canvas.outputs.canvas-id
+        uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.4
+        with:
+          command: update-workflow
+          step-id: ${{ env.CURRENT_STEP }}
+          workflow-status: failed
+          step-status: failed
+        name: Mark workflow as failed
+
+      - if: always() && steps.create-canvas.outputs.canvas-id
+        uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.4
+        with:
+          command: remove-step
+          step-id: '*'
+          step-status: succeeded
+        name: Clean up workflow canvas
+
+      - if: success()
+        uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.4
+        with:
+          command: update-workflow
+          workflow-status: succeeded
+        name: Mark workflow as successful
+
+      - if: always() && steps.create-canvas.outputs.canvas-id
+        uses: uwit-iam/actions/update-slack-workflow-canvas@0.1.4
+        with:
+          command: finalize-workflow
+        name: Finalize workflow

--- a/docker/deployment.dockerfile
+++ b/docker/deployment.dockerfile
@@ -1,0 +1,7 @@
+# This image only exists as a final layer to add on top
+# in order for flux to ALWAYS deploy. This is likely temporary,
+# as flux v2 should give us more flexibility in how we deploy.
+ARG IMAGE
+ARG DEPLOYMENT_ID
+FROM IMAGE AS release
+ENV DEPLOYMENT_ID=${DEPLOYMENT_ID}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,59 @@
+# Deployment
+
+Deploying a new version of the directory simply requires that a new
+docker image be tagged in the format of 
+
+`deploy-<stage>.<deployment-id>`
+
+`<stage>` refers to `dev`, `eval`, or `prod`.
+
+`<deployment-id>` can be any unique identifier, but when automated will be a 
+pseduo-semver timestamp, for example: `2021.1.13.14.24` would represent
+a deployment tagged on January 13, 2021, at 2:24 pm. 
+
+Please see [release-process.md] for more information on the how, why, 
+and what of tagging and versioning.
+
+## Deploying manually
+
+### ... via Github Actions
+
+**This is only available to people who have write access to the Github repository**.
+
+To deploy via Github Actions, simply visit the [workflow], then click `Run workflow`. 
+Fill out the brief form using the guidance provided by [release-process.md]. Then 
+click the next `Run workflow` button. All deployment operations will notify the
+`#cloud-native-directory` slack channel.
+
+**RFC Number** is required if deploying to `prod`. 
+If no **version** is specified, a [promotion](#promotions) will occur instead.
+
+
+### ... from your terminal
+
+**This is only available to people who have write access to the GCR repository.**
+
+Use `./scripts/deploy.sh -t <stage> -v <version> -r <rfc_number>` 
+
+`-r, --rfc-number` is required if `-t`argeting `prod`.
+
+If no `-v`ersion is specified, a [promotion](#promotions) will occur instead.
+
+# Promotions
+
+A promotion is simply a deployment that doesn't require a version input, because the 
+version is sourced from the previous stage.
+
+A promotion _to_ `dev` will deploy the latest tag on the repository.
+A promotion _to_ `eval` will deploy the version to eval that is currently deployed to 
+dev.
+A promotion _to_ `prod` will deploy the version to prod that is currently deployed 
+to eval.
+
+When promoting to `eval` or `prod`, the previous stage's deployed version will be 
+derived from that instance's `/health` endpoint, which includes the 
+`version` information.
+
+
+[release-process.md]: release-process.md
+[workflow]: https://github.com/uwit-iam/uw-husky-directory/...

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,100 @@
+# Release Process
+
+This product is released in three stages: `dev`, `eval`, and `prod`.
+
+Additionally, all releases are versioned using [semver]. This process is
+mostly automated, but you should keep reading to understand the strategy
+and options available.
+
+## versioning
+
+A new version should be created any time a change is _accepted into the `main` branch_.
+In this way, every merge into this branch will be explicitly versioned, and will 
+therefore be available for deployments and as a rollback point.
+
+When you open a pull request (PR), your PR checks will fail until you supply
+a **semver-guidance label**. You can add this label directly from the 
+Github UI, as long as you have the correct permissions. If you don't, then your 
+PR reviewer can add this guidance for you.
+
+You should supply guidance using the following rhetoric:
+
+- `patch` if the change under review: fixes a bug, updates configuration, or 
+improves stability/performance without directly changing the user experience.
+- `minor` if the change under review: adds a new feature, directly changes the user 
+experience in any way.
+- `major` if the change under review: dramatically shifts the user experience (e.g., 
+a front-end redesign), turns off long-standing features, or otherwise departs from 
+the flow and experience users are used to.
+
+Each new version update to the `pyproject.toml` file (made using `poetry version 
+$NEW_VERSION`) should also correspond to an annotated git tag (e.g., `git tag -a 
+$NEW_VERSION && git push $NEW_VERSION`).
+
+This means that every change to the semver in `pyproject.toml` should be the HEAD of 
+a new tag matching that version.
+
+## docker tagging
+
+In addition to versioning the code and tagging the repo, this package makes liberal 
+use of docker tags to show the path of a change through time.
+
+- When a change is built by an automated process, the commit SHA is used to tag the 
+image (`husky-directory:commit-ABCDE1234`).
+- When a pull request is opened on a change, the PR number is used to create an 
+additional tag (`husky-directory:pull-request-123`).
+- When a change is accepted, and a new version is created, the image is tagged
+with the new version number (`husky-directory:2.3.4`).
+- When a change is deployed, a new image layer is created on top of the release 
+  that is tagged with the deployment id: (`husky-directory:deploy-dev.2021.9.1.11.39)`. 
+  The new layer is necessary because Flux (v1) uses _timestamps_ for non-semver
+  deployment automation, so we must necessarily create a new layer that has an updated
+  timestamp.
+
+In this way, you can review the docker repository to see the complete history of a 
+change. 
+
+For instance, if you saw that an image had the all the above tags, you would know
+that pull request 123 was opened for commit ABCDE1234. When the pull request was 
+accepted, it generated the 2.3.4 version of the application, which was then deployed
+to dev on September 1, 2021, at 11:39 am. Once the change is released to eval and prod,
+you would also see additional `deploy-eval` and `deploy-prod` tags, respectively.
+
+The use case for the `deploy-dev.<timestamp>` tag is to allow us to _roll back to 
+any previous version at any time._ Relying only on the semver for a deployment
+makes it hard to roll an instance back, because flux (our automated deployment tool)
+only deploys progressively. 
+
+By triggering our deployments on the `deploy-<stage>.<timestamp>` pattern, flux will
+always deploy the latest deploy _timestamp_, no matter which version it's attached 
+to. Additionally, any rollback deployments will be evident in the tagging history
+for a given image.
+
+
+## Stages
+
+This section talks only about how and when deployments occur. To find out about
+deploying manually, read [deployment.md](deployment.md).
+
+### Releasing to dev
+
+Releases to dev should occur whenever a new version is created. 
+
+Releases to dev are done **AUTOMATICALLY** any time a change is accepted into 
+the `main` branch. If there are any problems, you may deploy to dev manually.
+
+### Releasing to eval
+
+Releases to eval should occur at least a week prior to any desired release to prod. 
+However, in an ideal world, eval would be kept up to date with dev in real time. 
+Currently there is no automation, so this must be done manually.
+
+### Releasing to prod
+
+Releases to prod must have an RFC that includes a communications plan. Because this is 
+a publicly available product, we should take care to avoid any downtime, and provide 
+adequate communications if any downtime is required. 
+
+
+
+[semver]: https://www.semver.org

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-husky-directory"
-version = "1.0.1"
+version = "1.0.2"
 description = "An updated version of the UW Directory"
 authors = ["Thomas Thorogood <goodtom@uw.edu>"]
 license = "MIT"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+
+REPO_API_URL=https://api.github.com/repos/uwit-iam/uw-husky-directory
+
+REPO_TAGS_URL="${REPO_API_URL}/tags"
+REPO_RELEASE_URL="${REPO_API_URL}/release/latest"
+
+function print_help {
+   cat <<EOF
+   Use: deploy.sh [--debug --help]
+   For more, see docs/deployment.md
+   Options:
+   -v, --version         The version to deploy. If not provided, a promotion will take
+                         place, instead (eval promotes from dev, prod promotes from
+                         eval).
+
+   -t, --target-cluster  The cluster to deploy to. Choose from: dev, eval, prod.
+
+   -r, --rfc-number      If deploying to prod, the RFC number is required.
+                         You only need ot provide the number.
+   -w, --wait-time-secs  The number of seconds to wait for the deployment to be ready.
+                         Default is 600 (10 minutes).
+   -x, --dry-run         Do not actually push the tag.
+
+   --dev-promotion-strategy   By default, we deploy the latest github tag to dev;
+                              however you can choose to deploy any of the following
+                              when running manually:
+                                  tag       [Default] The latest tag known to github,
+                                            from: $REPO_TAGS_URL
+
+                                  release   The latest release known to github,
+                                            from: $REPO_RELEASES_URL
+
+   -h, --help            Show this message and exit
+
+   -g, --debug           Show commands as they are executing
+EOF
+}
+
+WAIT_TIME_SECS=600
+DEV_STRATEGY=tag
+
+while (( $# ))
+do
+  case $1 in
+    --version|-v)
+      shift
+      deploy_version="$1"
+      ;;
+    --configure-only)
+      CONFIGURE_ONLY=1
+      ;;
+    --target-cluster|-t)
+      shift
+      target_cluster="$1"
+      ;;
+    --rfc-number|-r)
+      shift
+      rfc_number="$1"
+      ;;
+    --wait-time-secs|-w)
+      shift
+      WAIT_TIME_SECS=$1
+      ;;
+    --dev-promotion-strategy)
+      shift
+      DEV_STRATEGY="$1"
+      ;;
+    --dry-run|-x)
+      DRY_RUN=1
+      ;;
+    --help|-h)
+      print_help
+      exit 0
+      ;;
+    --debug|-g)
+      set -x
+      ;;
+    *)
+      echo "Invalid Option: $1"
+      print_help
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+function semver_timestamp {
+  # Not really semver at all, but increments in a way that
+  # is compatible and unique.
+  echo $(date +%Y.%-m.%-d.%-H.%-M.%-S)
+}
+
+
+function version_image_tag {
+  local version="$1"
+  echo "gcr.io/uwit-mci-iam/husky-directory:$version"
+}
+
+function deploy_image_tag {
+  local stage="$1"
+  echo "gcr.io/uwit-mci-iam/husky-directory:deploy-${stage}.$(semver_timestamp)"
+}
+
+function get_version {
+    local stage="$1"
+    local url="https://directory.iam${stage}.s.uw.edu/health"
+    local stage_status=$(curl -sk $url)
+    local version=$(echo "$stage_status" | jq .version | sed 's|"||g')
+    echo "$version"
+}
+
+function get_latest_github_tag {
+  case "${DEV_STRATEGY}" in
+    tag)
+      tags=$(curl -sk ${REPO_TAGS_URL})
+      echo "$tags" | jq '.[0].name' | sed 's|"||g'
+      ;;
+    release)
+      release=$(curl -sk ${REPO_RELEASES_URL})
+      echo "$release" | jq .name | sed 'S|"||g'
+      ;;
+    *)
+      >&2 echo "Invalid dev promotion strategy: ${DEV_STRATEGY}."
+      >&2 echo "Choose from: tag, release"
+      return 1
+      ;;
+  esac
+}
+
+function configure_deployment {
+  # Cluster is always a required argument.
+  test -z "${target_cluster}" && echo "--target-cluster/-t must be supplied" && return 1
+  test -n "${deploy_version}" && return 0
+  # If no version was explicitly provided, we have to
+  # determine the promotion version.
+  case "${target_cluster}" in
+    dev)
+      echo "Determining deployment version for dev from latest github tag."
+      deploy_version=$(get_latest_github_tag)
+      echo "No version supplied, deploying latest tag ($deploy_version) to dev."
+      ;;
+    eval)
+      deploy_version=$(get_version dev)
+      echo "No version supplied, promoting $deploy_version from dev to eval."
+      ;;
+    prod)
+      if [[ -z "${rfc_number}" ]]
+      then
+        >&2 echo "--rfc-number/-r required when target is prod!"
+        return 1
+      fi
+      deploy_version=$(get_version eval)
+      echo "No version supplied, promoting $deploy_version from eval to prod."
+      ;;
+    *)
+      echo "No promotion configured for cluster: ${target_cluster}"
+      return 1
+      ;;
+  esac
+  if [[ -n "${GITHUB_REF}" ]]
+  then
+    echo "::set-output name=target-cluster::$target_cluster"
+    echo "::set-output name=target-version::$deploy_version"
+  fi
+}
+
+function wait_for_version_update {
+  local attempts=0
+  local pause_secs=10
+  local max_attempts=$(( $WAIT_TIME_SECS / $pause_secs ))
+  while [[ -n "1" ]]
+  do
+    attempts=$(( $attempts+1 ))
+    if [[ "$attempts" -gt "$max_attempts" ]]
+    then
+      echo "Deployment did not complete within $WAIT_TIME_SECS seconds; aborting."
+      return 1
+    fi
+    local cur_version=$(get_version $target_cluster)
+    if [[ "$cur_version" == "$deploy_version" ]]
+    then
+      echo "Deployed version matches target of $deploy_version"
+      return 0
+    fi
+    echo "Attempt #${attempts}: Deployed $target_cluster version is $cur_version, waiting for $new_version" [$(date)]""
+    sleep 10
+  done
+}
+
+function pull_version {
+  local version="$1"
+  local image=$(version_image_tag $version)
+  if ! docker pull $image
+  then
+    >&2 echo "Could not pull docker image $image"
+    return 1
+  fi
+}
+
+function deploy {
+  gcloud auth configure-docker
+  local version_tag=$(version_image_tag $deploy_version)
+  local deploy_tag=$(deploy_image_tag $target_cluster)
+  pull_version $deploy_version
+  docker build -f docker/deployment.yml \
+    --build-arg IMAGE=$deploy_version \
+    --build-arg DEPLOYMENT_ID=$deploy_tag \
+    -t $deploy_tag
+  echo "Tagged $deploy_version for deployment: $deploy_tag"
+  if [[ -z "${DRY_RUN}" ]]
+  then
+    echo "Pushing tag $deploy_tag"
+    docker push $deploy_tag
+    if [[ -n "$GITHUB_REF" ]]
+    then
+      echo "::set-output name=deployed-tag::$deploy_tag"
+    fi
+    echo "Waiting for deployment to complete."
+    wait_for_version_update
+  else
+    echo "Not pushing; dry-run only."
+  fi
+}
+
+set -e
+configure_deployment
+if [[ -z "${CONFIGURE_ONLY}}" ]]
+then
+  deploy
+fi


### PR DESCRIPTION
Adds two workflows:

- A `create-release` workflow that creates a new release when we merge into main from a pull request
- A `deploy` workflow that is triggered when a release is created, and pushes that release to dev. Additionally, it can be triggered manually to deploy to eval or prod.

Note that both workflows have only been tested in their dry-run modes; they cannot be further validated until merged in.