### PR TITLE
Fix hard-coded ACS url and null RelayState with SAML flow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -59,6 +59,7 @@ jobs:
         with:
           add: pyproject.toml
           default_author: github_actions
+          pull_strategy: NO-PULL
           push: true
           message: "[Bot] Update version to ${{ env.version }}"
 

--- a/husky_directory/app_config.py
+++ b/husky_directory/app_config.py
@@ -117,7 +117,7 @@ class RedisSettings(FlaskConfigurationSettings):
 
 class SessionSettings(FlaskConfigurationSettings):
     cookie_name: str = Field(
-        "edu.uw.identity.session", env="SESSION_COOKIE_NAME", flask_config_key="_env"
+        "edu.uw.directory.session", env="SESSION_COOKIE_NAME", flask_config_key="_env"
     )
     secret_key: SecretStr = Field(None, env="SECRET_KEY", flask_config_key="_env")
     lifetime_seconds: int = Field(
@@ -154,7 +154,7 @@ class AuthSettings(FlaskConfigurationSettings):
     uwca_cert_name: str = Field(..., env="UWCA_CERT_NAME")
     uwca_cert_path: str = Field(..., env="UWCA_CERT_PATH")
     saml_entity_id: str = Field(..., env="SAML_ENTITY_ID")
-    saml_acs_url: str = Field(..., env="SAML_ACS_URL")
+    saml_acs_path: str = Field(..., env="SAML_ACS_PATH")
     use_test_idp: bool = Field(False, env="USE_TEST_IDP")
 
 

--- a/husky_directory/settings/base.dotenv
+++ b/husky_directory/settings/base.dotenv
@@ -4,4 +4,4 @@ PWS_HOST=https://it-wseval1.s.uw.edu
 PWS_DEFAULT_PATH=/identity/v2
 HOST=directory.iamdev.s.uw.edu
 SAML_ENTITY_ID=https://${HOST}/saml
-SAML_ACS_URL=https://${HOST}/saml/login
+SAML_ACS_PATH=/saml/login

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-husky-directory"
-version = "1.2.3"
+version = "1.2.4"
 description = "An updated version of the UW Directory"
 authors = ["Thomas Thorogood <goodtom@uw.edu>"]
 license = "MIT"


### PR DESCRIPTION
Assuming https://directory-alt.iamdev.s.uw.edu/saml/login works at some point, then this PR fixes the issue. Currently waiting for an issue with SP registry syncing to be resolved. Please don't approve or merge this change unless the issue is resolved without any iterations to this PR.

This change is already running in dev as version 1.2.3-rc.6