### PR TITLE
Remove /search GET endpoint as a json interface.

### DIFF
--- a/husky_directory/blueprints/search.py
+++ b/husky_directory/blueprints/search.py
@@ -2,7 +2,7 @@ from base64 import b64decode
 from logging import Logger
 from typing import Optional
 
-from flask import Blueprint, Request, jsonify, redirect, render_template, send_file
+from flask import Blueprint, Request, redirect, render_template, send_file
 from inflection import humanize, underscore
 from injector import Injector, inject, singleton
 from pydantic import ValidationError
@@ -62,23 +62,13 @@ class SearchBlueprint(Blueprint):
         # singleton instance)
         return self.injector.get(VCardService)
 
-    def get(self, request: Request, search_service: DirectorySearchService):
+    def get(self, request: Request):
         """
-        An API call, returning JSON output. Not actively used by
-        any existing flows, but useful for testing/debugging,
-        and may be useful to customers. Uses the SearchDirectoryInput model
-        by way of query parameters.
-            directory.uw.edu/search?name=foo&population=employees
-
-        Returns a jsonified instance of SearchDirectoryOutput
+        The /search endpoint only supports POST, but because it
+        will appear in users' browser histories, we set a default GET
+        path to nicely redirect back to the home page.
         """
-        if not request.args:
-            return redirect("/")
-
-        request_input = SearchDirectoryInput.parse_obj(request.args)
-        self.logger.info(f"searching for {request_input}")
-        request_output = search_service.search_directory(request_input)
-        return jsonify(request_output.dict(by_alias=True, exclude_none=True))
+        return redirect("/")
 
     def get_person(
         self,

--- a/husky_directory/templates/summary_results_table/scenario_population_block.html
+++ b/husky_directory/templates/summary_results_table/scenario_population_block.html
@@ -17,7 +17,7 @@ and then 1 or more rows of results. #}
 
 {# data: models.search.Person #}
 {% for data in population['people'] %}
-    <tr>
+    <tr class="summary-row">
         <td valign="top">{{ data['name'] }}&nbsp;</td>
         <td valign="top" nowrap="nowrap">
             {{ data['phone_contacts']['phones']|first }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-husky-directory"
-version = "1.2.4"
+version = "1.3.0"
 description = "An updated version of the UW Directory"
 authors = ["Thomas Thorogood <goodtom@uw.edu>"]
 license = "MIT"

--- a/tests/blueprints/test_metrics_blueprint.py
+++ b/tests/blueprints/test_metrics_blueprint.py
@@ -1,0 +1,5 @@
+class TestMetrics:
+    def test_placeholder(self, client):  # This is just here to keep coverage happy
+        response = client.get("/metrics")
+        assert response.status_code == 200
+        assert response.data.decode("UTF-8") == "OK"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -56,9 +56,9 @@ def test_get_logout(client):
     assert response.status_code == 302, response.data
 
 
-def test_bad_request_error(client):
+def test_search_get_redirect(client):
     response = client.get("/search?boxNumber=ABCDEFG")
-    assert response.status_code == 400
+    assert response.status_code == 302
 
 
 def test_internal_server_error(client, injector, mock_injected):
@@ -66,5 +66,7 @@ def test_internal_server_error(client, injector, mock_injected):
     with mock_injected(DirectorySearchService, service):
         mock_search = mock.patch.object(service, "search_directory").start()
         mock_search.side_effect = RuntimeError
-        response = client.get("/search?boxNumber=123456")
+        response = client.post(
+            "/search", data={"method": "boxNumber", "query": "123456"}
+        )
         assert response.status_code == 500


### PR DESCRIPTION
Closes EDS-585

- Updates tests to account for new behavior
- If a user types (or uses a back button) to get to `/search`, they will
be silently redirected back to `/` instead of causing a MethodNotAllowed error.
- Adds a placeholder test for the metrics placeholder (for coverage)