### PR TITLE
Don't display any output for a phone number if a user's is blank.

### DIFF
--- a/husky_directory/templates/summary_results_table/scenario_population_block.html
+++ b/husky_directory/templates/summary_results_table/scenario_population_block.html
@@ -20,7 +20,8 @@ and then 1 or more rows of results. #}
     <tr class="summary-row">
         <td valign="top">{{ data['name'] }}&nbsp;</td>
         <td valign="top" nowrap="nowrap">
-            {{ data['phone_contacts']['phones']|first }}
+            {% set phone = data['phone_contacts']['phones']|first %}
+            {% if phone %}{{ phone }}{% endif %}
         </td>
         <td valign="top">{{ data['email'] }}&nbsp;</td>
         <td>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-husky-directory"
-version = "1.3.0"
+version = "1.3.1"
 description = "An updated version of the UW Directory"
 authors = ["Thomas Thorogood <goodtom@uw.edu>"]
 license = "MIT"


### PR DESCRIPTION
Fixes a minor issue with student listings where because we don't show student numbers (unless they are also an employee with an employee phone number), the value was being set to None instead of an empty list. The `None` value was being output explicitly, which we didn't want.

so, now we only show a phone number if it has a non-blank value.
