### PR TITLE
Support 'semver-guidance:no-bump' to indicate a PR is a docs-only update

### DIFF
--- a/.github/steps/create-release/is-release-required.sh
+++ b/.github/steps/create-release/is-release-required.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+set -ex
 source .build-scripts/sources/github-actions.sh
 
 current_version=$(poetry version -s)

--- a/.github/steps/create-release/is-release-required.sh
+++ b/.github/steps/create-release/is-release-required.sh
@@ -3,8 +3,7 @@
 source .build-scripts/sources/github-actions.sh
 
 current_version=$(poetry version -s)
-releases=$(curl -s https://api.github.com/repos/UWIT-IAM/uw-husky-directory/tags)
-latest_release=$(curl -s https://api.github.com/repos/UWIT-IAM/uw-husky-directory/tags | jq '.[0].name')
+latest_release=$(curl -s https://api.github.com/repos/UWIT-IAM/uw-husky-directory/releases | jq '.[0].tag_name')
 
 set_ci_output version "${current_version}"
 set_ci_output latest-release "${latest_release}"

--- a/.github/steps/create-release/is-release-required.sh
+++ b/.github/steps/create-release/is-release-required.sh
@@ -4,6 +4,7 @@ source .build-scripts/sources/github-actions.sh
 
 current_version=$(poetry version -s)
 latest_release=$(curl -s https://api.github.com/repos/UWIT-IAM/uw-husky-directory/releases | jq '.[0].tag_name')
+latest_release=$(echo "${latest_release}" | sed 's|"||g')
 
 set_ci_output version "${current_version}"
 set_ci_output latest-release "${latest_release}"

--- a/.github/steps/create-release/is-release-required.sh
+++ b/.github/steps/create-release/is-release-required.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+source .build-scripts/sources/github-actions.sh
+
+current_version=$(poetry version -s)
+releases=$(curl -s https://api.github.com/repos/UWIT-IAM/uw-husky-directory/tags)
+latest_release=$(curl -s https://api.github.com/repos/UWIT-IAM/uw-husky-directory/tags | jq '.[0].name')
+
+set_ci_output version "${current_version}"
+set_ci_output latest-release "${latest_release}"
+if [[ "${current_version}" == "${latest_release}" ]]
+then
+  set_ci_output release-required false
+else
+  set_ci_output release-required true
+fi

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -16,6 +16,9 @@ jobs:
       latest-release: ${{ steps.get-release.outputs.latest-release }}
     steps:
       - uses: actions/checkout@v2
+      - name: Install poetry
+        uses: abatilo/actions-poetry@v2.1.0
+      - run: ./scripts/install-build-scripts.sh
       - run: ${STEP_SCRIPTS}/is-release-required.sh
         id: get-release
         name: Get version and determine release requirement

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -3,17 +3,29 @@ on:
     branches:
       - main
       - dry-run-create-release
-    paths-ignore:
-      - '*.md'
 
 env:
   STEP_SCRIPTS: ${{ github.workspace }}/.github/steps/create-release
 
 jobs:
-  create-release:
+  configure-release:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.get-version.outputs.version }}
+      release-required: ${{ steps.get-release.outputs.release-required }}
+      version: ${{ steps.get-release.outputs.version }}
+      latest-release: ${{ steps.get-release.outputs.latest-release }}
+    steps:
+      - uses: actions/checkout@v2
+      - run: ${STEP_SCRIPTS}/is-release-required.sh
+        id: get-release
+        name: Get version and determine release requirement
+
+  create-release:
+    needs: [configure-release]
+    if: needs.configure-release.outputs.release-required == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.get-release.outputs.version }}
     strategy:
       max-parallel: 1
     steps:
@@ -35,10 +47,6 @@ jobs:
 
       - run: gcloud auth configure-docker gcr.io
 
-      - run: echo ::set-output name=version::$(poetry version -s)
-        id: get-version
-        name: Get merged version
-
       - run: ./scripts/pre-push.sh --headless --no-commit
         name: Validate build
 
@@ -51,16 +59,16 @@ jobs:
       - name: Tag and push release image
         env:
           pr_image: gcr.io/${{ secrets.IAM_GCR_REPO }}/husky-directory:pull-request-${{ steps.pr.outputs.number }}
-          release_image: gcr.io/${{ secrets.IAM_GCR_REPO }}/husky-directory:${{ steps.get-version.outputs.version }}
+          release_image: gcr.io/${{ secrets.IAM_GCR_REPO }}/husky-directory:${{ steps.get-release.outputs.version }}
           # When using the dry-run branch, there is no PR to draw from, so we hard-code
           # a known-good image.
           testing_image: gcr.io/${{ secrets.IAM_GCR_REPO }}/husky-directory:1.0.1
         run: ${STEP_SCRIPTS}/push-release-image.sh
 
-      - name: Create release ${{ steps.get-version.outputs.version }}
+      - name: Create release ${{ steps.get-release.outputs.version }}
         uses: ncipollo/release-action@v1
         with:
           # Use PAT so that the release will trigger the deployment workflow.
           token: ${{ secrets.ACTIONS_PAT }}
-          tag: ${{ steps.get-version.outputs.version }}
+          tag: ${{ steps.get-release.outputs.version }}
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,7 +3,8 @@ name: Pull request validation workflow
 on:
   pull_request:
     paths-ignore:
-      - '*.md'
+      - '**.md'
+      - 'docs/**'
     types:
       - opened
       - synchronize
@@ -32,13 +33,17 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.base.ref }}
+        if: steps.guidance.outputs.guidance != 'no-bump'
 
       - run: echo ::set-output name=version::$(poetry version -s)
         id: get-version
+        if: steps.guidance.outputs.guidance != 'no-bump'
 
       - uses: actions/checkout@v2
+        if: steps.guidance.outputs.guidance != 'no-bump'
 
       - name: Update PR version to base_version+guidance
+        if: steps.guidance.outputs.guidance != 'no-bump'
         env:
           BASE_VERSION: ${{ steps.get-version.outputs.version }}
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,9 +2,6 @@ name: Pull request validation workflow
 
 on:
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
     types:
       - opened
       - synchronize

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -19,6 +19,8 @@ PR reviewer can add this guidance for you.
 
 You should supply guidance using the following rhetoric:
 
+- `no-bump` if the change under review does not alter ANY functionality (i.e., only
+  changes documentation).
 - `patch` if the change under review: fixes a bug, updates configuration, or 
 improves stability/performance without directly changing the user experience.
 - `minor` if the change under review: adds a new feature, directly changes the user 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-husky-directory"
-version = "2.0.1"
+version = "2.0.0"
 description = "An updated version of the UW Directory"
 authors = ["Thomas Thorogood <goodtom@uw.edu>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-husky-directory"
-version = "2.0.1-alpha.0"
+version = "2.0.1"
 description = "An updated version of the UW Directory"
 authors = ["Thomas Thorogood <goodtom@uw.edu>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-husky-directory"
-version = "2.0.0"
+version = "2.0.1"
 description = "An updated version of the UW Directory"
 authors = ["Thomas Thorogood <goodtom@uw.edu>"]
 license = "MIT"


### PR DESCRIPTION
This change allows setting the `semver-guidance:no-bump` label to indicate that a pull request should _not_ result in generating a new version and release. (For instance, when updating docs.)