### PR TITLE
Export additional statistics when logging timer contexts.

### DIFF
--- a/husky_directory/logging.py
+++ b/husky_directory/logging.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import threading
 import traceback
 from typing import Any, Dict, Optional, Type, TypeVar
@@ -12,6 +13,7 @@ from werkzeug.local import LocalProxy
 T = TypeVar("T")
 
 ROOT_LOGGER = "gunicorn.error"
+PRETTY_JSON = os.environ.get("FLASK_ENV", "production") == "development"
 
 
 class JsonFormatter(logging.Formatter):
@@ -106,7 +108,10 @@ class JsonFormatter(logging.Formatter):
         self._append_custom_attrs(record, data)
         self._append_exception_info(record, data)
 
-        return json.dumps(data, default=str)
+        kwargs = {}
+        if PRETTY_JSON:
+            kwargs["indent"] = 4
+        return json.dumps(data, default=str, **kwargs)
 
 
 def build_extras(attrs: Dict) -> Dict:

--- a/husky_directory/services/translator.py
+++ b/husky_directory/services/translator.py
@@ -80,10 +80,12 @@ class ListPersonsOutputTranslator:
             PopulationType.students: DirectoryQueryPopulationOutput(
                 population=PopulationType.students
             ),
+            "__META__": {},
         }
-
+        num_duplicates_found = 0
         for person in request_output.persons:
             if person.netid in netid_tracker:
+                num_duplicates_found += 1
                 continue
 
             student = person.affiliations.student
@@ -105,4 +107,5 @@ class ListPersonsOutputTranslator:
                 results[PopulationType.employees].people.append(result)
 
             netid_tracker.add(person.netid)
+        results["__META__"]["duplicates"] = num_duplicates_found
         return results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-husky-directory"
-version = "2.0.4"
+version = "2.0.5"
 description = "An updated version of the UW Directory"
 authors = ["Thomas Thorogood <goodtom@uw.edu>"]
 license = "MIT"


### PR DESCRIPTION
This isn't my prettiest work, but it'll help us with our optimizations.

Our request timers now include the following information: 

```javascript
{
    "query": {
        "name": "thom",
        "population": "all",
        "includeTestIdentities": false
    },
    "statistics": {  // NEW!
        "numPagesReturned": 18,
        "numResultsIgnored": 1429,
        "numResultsReturned": 2633,
        "numUserSearchTokens": 1,
        "numQueriesGenerated": 10,
        "numDuplicatesFound": 422
    },
    "timer": {
        "name": "search_directory",
        "timerResult": 3.537,
        "startTime": 1631832347.8775764,
        "endTime": 1631832351.4141982
    }
}
```