### PR TITLE
Fix release workflow no longer being compatible with a previous update

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -50,7 +50,7 @@ jobs:
 
       - run: gcloud auth configure-docker gcr.io
 
-      - run: ./scripts/pre-push.sh --headless --no-commit
+      - run: ./scripts/pre-push.sh --headless
         name: Validate build
 
       - name: Actions Ecosystem Action Get Merged Pull Request


### PR DESCRIPTION
This is currently blocking things deploying to dev. (We didn't find out sooner because our automation has been turned off the past couple of days during the flux upgrade.)