### PR TITLE
[EDS-599] Support 2-character name searches, plus other fixes!

### DIFF
--- a/husky_directory/app.py
+++ b/husky_directory/app.py
@@ -12,10 +12,9 @@ from flask_injector import FlaskInjector, request
 from flask_session import RedisSessionInterface, Session
 from injector import Injector, Module, provider, singleton
 from jinja2.tests import test_undefined
-from pydantic import ValidationError
 from redis import Redis
 from uw_saml2 import mock, python3_saml
-from werkzeug.exceptions import BadRequest, HTTPException, InternalServerError
+from werkzeug.exceptions import HTTPException, InternalServerError
 from werkzeug.local import LocalProxy
 
 from husky_directory.blueprints.app import AppBlueprint
@@ -35,10 +34,6 @@ from .app_config import (
 
 
 def attach_app_error_handlers(app: Flask) -> NoReturn:
-    @app.errorhandler(ValidationError)
-    def handle_validation_errors(e: ValidationError):
-        return BadRequest(str(e))
-
     @app.errorhandler(Exception)
     def log_all_errors(e: Exception):
         if isinstance(e, HTTPException):

--- a/husky_directory/models/pws.py
+++ b/husky_directory/models/pws.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, List, NoReturn, Optional
 
-from inflection import titleize
+from inflection import humanize
 from pydantic import BaseModel, Extra, Field, validator
 
 from .common import RecordConstraint, UWDepartmentRole
@@ -185,8 +185,16 @@ class NamedIdentity(PWSBaseModel):
     )
     def humanize_name_field(cls, value: Optional[str]) -> Optional[str]:
         if value:
-            return titleize(value)
+            return " ".join(humanize(v) for v in value.split())
         return value
+
+    def get_displayed_surname(self):
+        display_name_tokens = self.display_name.split()
+        if self.preferred_last_name and self.preferred_last_name in display_name_tokens:
+            return self.preferred_last_name
+        elif self.registered_surname in display_name_tokens:
+            return self.registered_surname
+        return self.display_name.split()[-1]
 
 
 class PersonOutput(NamedIdentity):

--- a/husky_directory/services/query_generator.py
+++ b/husky_directory/services/query_generator.py
@@ -381,7 +381,34 @@ class SearchQueryGenerator:
             ),
         )
 
+    def _generate_short_name_queries(self, name: str) -> GeneratedQuery:
+        """
+        For very short queries, we should make the assumption that the user
+        is search for a short first name or short surname. We should NOT
+        do "contains" searches as there are likely to be a lot of irrelevant results.gtgt
+        :param name:
+        :return:
+        """
+        yield GeneratedQuery(
+            description=f'First name starts with "{name}"',
+            request_input=ListPersonsInput(
+                employee_affiliation_state=AffiliationState.current,
+                display_name=f"{name}*",
+            ),
+        )
+        yield GeneratedQuery(
+            description=f'Last name starts with "{name}"',
+            request_input=ListPersonsInput(
+                employee_affiliation_state=AffiliationState.current,
+                display_name=f"* {name}*",
+            ),
+        )
+
     def generate_name_queries(self, name: str) -> Tuple[str, ListPersonsInput]:
+        if len(name) == 2:
+            yield from self._generate_short_name_queries(name)
+            return
+
         # No matter the case, we will always be checking for an exact match
         yield GeneratedQuery(
             description=f'Name matches "{name}"',

--- a/husky_directory/services/translator.py
+++ b/husky_directory/services/translator.py
@@ -93,7 +93,7 @@ class ListPersonsOutputTranslator:
 
             result = Person(
                 name=person.display_name,
-                sort_key=person.preferred_last_name or person.registered_surname,
+                sort_key=person.get_displayed_surname(),
                 phone_contacts=self._resolve_phones(employee, student),
                 **person.dict()
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-husky-directory"
-version = "2.0.6"
+version = "2.0.7"
 description = "An updated version of the UW Directory"
 authors = ["Thomas Thorogood <goodtom@uw.edu>"]
 license = "MIT"

--- a/tests/blueprints/test_search_blueprint.py
+++ b/tests/blueprints/test_search_blueprint.py
@@ -381,6 +381,7 @@ class TestSearchBlueprint(BlueprintSearchTestBase):
     def test_list_people_sort(self, random_string):
         ada_1 = self.mock_people.published_employee.copy(
             update={
+                "display_name": "Ada Zlovelace",
                 "preferred_last_name": "Zlovelace",
                 "registered_surname": "Alovelace",
                 "netid": random_string(),
@@ -390,6 +391,7 @@ class TestSearchBlueprint(BlueprintSearchTestBase):
         ada_1.affiliations.employee.directory_listing.phones = ["222-2222"]
         ada_2 = self.mock_people.published_employee.copy(
             update={
+                "display_name": "Ada Blovelace",
                 "registered_surname": "Blovelace",
                 "netid": random_string(),
             },
@@ -398,6 +400,7 @@ class TestSearchBlueprint(BlueprintSearchTestBase):
         ada_2.affiliations.employee.directory_listing.phones = ["888-8888"]
         ada_3 = self.mock_people.published_employee.copy(
             update={
+                "display_name": "Ada Alovelace",
                 "preferred_last_name": "Alovelace",
                 "netid": random_string(),
             },

--- a/tests/blueprints/test_search_blueprint.py
+++ b/tests/blueprints/test_search_blueprint.py
@@ -114,7 +114,9 @@ class TestSearchBlueprint(BlueprintSearchTestBase):
         with self.html_validator.validate_response(response) as html:
             assert not html.find("table", summary="results")
             assert html.find(string=re.compile("Encountered error"))
-            self.html_validator.assert_has_tag_with_text("b", "invalid box number")
+            self.html_validator.assert_has_tag_with_text(
+                "b", "box number (input can only contain digits)"
+            )
 
     def test_render_full_no_box_number(self):
         self.mock_send_request.return_value = self.mock_people.as_search_output(

--- a/tests/models/test_pws_models.py
+++ b/tests/models/test_pws_models.py
@@ -1,3 +1,5 @@
+import pytest
+
 from husky_directory.models.pws import NamedIdentity, PersonOutput
 
 
@@ -32,3 +34,36 @@ def test_person_output_href():
         regid="ABCDE123",
     )
     assert out.href == "/identity/v2/person/ABCDE123/full.json"
+
+
+@pytest.mark.parametrize(
+    "model, expected",
+    [
+        (
+            NamedIdentity(registered_surname="smith", display_name="j h roberts"),
+            "Roberts",
+        ),
+        (
+            NamedIdentity(registered_surname="smith", display_name="j h finney-smith"),
+            "Finney-smith",
+        ),
+        # This is an unlikely case where a person has a display_name that differs from their registered_name, but
+        # they haven't set a preferred_name. I'm not sure if this is even possible, but if it ever happens, we'll
+        # elect to honor the registered_surname as long as it is a token in the user's display name.
+        (
+            NamedIdentity(registered_surname="smith", display_name="j smith hannaford"),
+            "Smith",
+        ),
+        (
+            NamedIdentity(
+                registered_surname="smith",
+                preferred_last_name="hannaford",
+                display_name="j smith hannaford",
+            ),
+            "Hannaford",
+        ),
+        (NamedIdentity(registered_surname="smith", display_name="j h smith"), "Smith"),
+    ],
+)
+def test_get_displayed_surname(model: NamedIdentity, expected):
+    assert model.get_displayed_surname() == expected

--- a/tests/models/test_search_models.py
+++ b/tests/models/test_search_models.py
@@ -90,3 +90,19 @@ class TestSearchDirectoryFormInput:
 def test_form_input_strips_illegal_chars(query_value, expected_value):
     form_input = SearchDirectoryFormInput(query=query_value)
     assert form_input.query == expected_value
+
+
+@pytest.mark.parametrize(
+    "query, method, is_valid",
+    [
+        ("", "name", False),
+        ("hi", "name", True),
+        ("hi", "department", False),
+        ("h", "name", False),
+    ],
+)
+def test_form_input_validation(query, method, is_valid):
+    try:
+        SearchDirectoryFormInput(query=query, method=method)
+    except ValidationError:
+        assert not is_valid

--- a/tests/services/test_query_generator.py
+++ b/tests/services/test_query_generator.py
@@ -94,6 +94,12 @@ class TestSearchQueryGenerator:
         ]
         assert expected_queries == actual_queries
 
+    def test_short_name_input(self):
+        generated = list(self.query_generator.generate(SearchDirectoryInput(name="hi")))
+        assert len(generated) == 2
+        assert generated[0].description == 'First name starts with "hi"'
+        assert generated[1].description == 'Last name starts with "hi"'
+
     def test_two_name_input(self):
         generated = list(
             self.query_generator.generate(SearchDirectoryInput(name="foo bar"))


### PR DESCRIPTION
**Change Description:** 

- Supports 2-character name queries (first iteration) [EDS-599]
- Enforces 3-character queries for all other fields
- Improves surname resolution when determining sort keys 
- Improves error messages seen by users

**Closes Jira(s)**: EDS-599

## UW-Directory Pull Request checklist

- [x] I have run `./scripts/pre-push.sh`
- [x] I have selected a `semver-guidance:` label for this pull request (under labels,
      to the right of the screen)
