### PR TITLE
Fix the "semver-date" strings which are not lexicographically sortable.

### DIFF
--- a/.github/steps/scheduled-maintenance/context-vars.src.sh
+++ b/.github/steps/scheduled-maintenance/context-vars.src.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+./scripts/install-build-scripts.sh
+source ./.build-scripts/sources/bash-helpers.sh
 source ./.build-scripts/sources/slack.sh
 source ./.build-scripts/sources/github-actions.sh
 
@@ -8,7 +10,7 @@ APP_IMAGE=${APP_IMAGE_REPO}
 PR_URL_BASE=${PR_URL_BASE}
 
 new_app_version=$(poetry version -s)
-new_di_version=$(date +%Y.%-j.%-I.%-M)
+new_di_version=$(tag_timestamp)
 di_fingerprint=$(./scripts/get-snapshot-fingerprint.sh)
 di_img_url=https://${BASE_IMAGE}:${new_di_version}
 app_img_url=https://${APP_IMAGE}:${new_app_version}

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -19,8 +19,7 @@ As a result of this workflow, the following artifacts will be created:
 
 1. A git tag of the new application version (e.g., 1.2.3)
 2. A dependency image tagged both with its sha256 fingerprint as well as the
-   pseduo-semver datetime "version" (e.g., 255.15.7, for a build that ran at 3:07pm 
-   on September 12).
+   timestamp tag.
 3. An application image tagged with its new patch version  (e.g., 1.2.3)
 4. A pull request that can be merged without careful review.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -7,9 +7,11 @@ docker image be tagged in the format of
 
 `<stage>` refers to `dev`, `eval`, or `prod`.
 
-`<deployment-id>` can be any unique identifier, but when automated will be a 
-pseduo-semver timestamp, for example: `2021.1.13.14.24` would represent
-a deployment tagged on January 13, 2021, at 2:24 pm. 
+`<deployment-id>` , can only be a  
+dot-separated timestamp (2021.01.13.14.24.45 would represent
+a deployment tagged on January 13, 2021, at 2:24:45 pm). 
+For convenience, you should use the tag_timestamp utility in 
+[common-build-scripts]()
 
 Please see [release-process.md] for more information on the how, why, 
 and what of tagging and versioning.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+./scripts/install-build-scripts.sh
+source ./.build-scripts/sources/bash-helpers.sh
+
 REPO_API_URL=https://api.github.com/repos/uwit-iam/uw-husky-directory
 
 REPO_TAGS_URL="${REPO_API_URL}/tags"
@@ -102,13 +105,6 @@ do
   shift
 done
 
-function semver_timestamp {
-  # Not really semver at all, but increments in a way that
-  # is compatible and unique.
-  echo $(date +%Y.%-m.%-d.%-H.%-M.%-S)
-}
-
-
 function version_image_tag {
   local version="$1"
   echo "gcr.io/uwit-mci-iam/husky-directory:$version"
@@ -116,10 +112,10 @@ function version_image_tag {
 
 function deploy_image_tag {
   local stage="$1"
-  qualifier=$(semver_timestamp)
+  qualifier=$(tag_timestamp)
   if [[ -n "${RELEASE_CANDIDATE}" ]]
   then
-    qualifier="$(whoami).${deploy_version}.${qualifier}"
+    qualifier="$${deploy_version}.${qualifier}.$(whoami)"
   fi
   echo "gcr.io/uwit-mci-iam/husky-directory:deploy-${stage}.${qualifier}"
 }


### PR DESCRIPTION
**Change Description:**

Updates how we tag our docker images so that our automation workflows can integrate safely with Flux v2

## UW-Directory Pull Request checklist

- [x] I have run `./scripts/pre-push.sh`
- [x] I have selected a `semver-guidance:` label for this pull request (under labels,
      to the right of the screen)
