### PR TITLE
[EDS-566] Improve 'More' functionality by using PWS person HREF…

### DIFF
--- a/husky_directory/models/pws.py
+++ b/husky_directory/models/pws.py
@@ -242,7 +242,7 @@ class ListPersonsRequestStatistics(BaseModel):
 
 class ListPersonsOutput(ListResponsesOutputWrapper):
     persons: List[PersonOutput]
-    current: ListPersonsInput
+    current: Optional[ListPersonsInput]
     next: Optional[ListPersonsInput] = Field(
         default=None,
         description="If present, gives the URL of the next page of "

--- a/husky_directory/models/search.py
+++ b/husky_directory/models/search.py
@@ -44,6 +44,7 @@ class SearchDirectoryFormInput(DirectoryBaseModel):
     query: str = ""
     population: PopulationType = PopulationType.employees
     length: ResultDetail = ResultDetail.summary
+    person_href: Optional[str]
 
     # render_ fields are provided as a way to search one thing,
     # but provide a different context to the rendering engine
@@ -133,6 +134,7 @@ class SearchDirectoryInput(DirectoryBaseModel):
     phone: Optional[str] = Field(None, search_method=True)
     population: PopulationType = PopulationType.employees
     include_test_identities: bool = False
+    person_href: Optional[str]
 
     @classmethod
     def search_methods(cls) -> List[str]:

--- a/husky_directory/templates/summary_results_table/scenario_population_block.html
+++ b/husky_directory/templates/summary_results_table/scenario_population_block.html
@@ -49,6 +49,9 @@ and then 1 or more rows of results. #}
                 <input id="{{ form_id }}-render-length"
                        type="hidden" name="render_length"
                        value="{{ request_input['length'] }}">
+                <input id="{{  form_id }}-person-href"
+                       type="hidden" name="person_href"
+                       value="{{  data['href'] }}" >
                 <!-- This option doesn't affect the query so can stay as-is -->
                 <input id="{{ form_id }}-population"
                        type="hidden" name="population"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-husky-directory"
-version = "2.0.7"
+version = "2.0.8"
 description = "An updated version of the UW Directory"
 authors = ["Thomas Thorogood <goodtom@uw.edu>"]
 license = "MIT"

--- a/tests/services/test_search.py
+++ b/tests/services/test_search.py
@@ -1,3 +1,4 @@
+import base64
 from contextlib import ExitStack
 from typing import Dict
 from unittest import mock
@@ -9,6 +10,7 @@ from husky_directory.models.common import UWDepartmentRole
 from husky_directory.models.enum import PopulationType
 from husky_directory.models.pws import (
     ListPersonsOutput,
+    PersonOutput,
 )
 from husky_directory.models.search import Person, SearchDirectoryInput
 from husky_directory.services.pws import PersonWebServiceClient
@@ -192,3 +194,12 @@ class TestDirectorySearchService:
         )
         output_person: Person = output.scenarios[0].populations["employees"].people[0]
         assert output_person.box_number == "351234"
+
+    def test_href_query(self):
+        href = base64.b64encode("foo".encode("UTF-8")).decode("UTF-8")
+        request_input = SearchDirectoryInput(person_href=href)
+        self.mock_get_explicit_href.return_value = self.mock_people.published_employee
+        self.client.search_directory(request_input)
+        self.mock_get_explicit_href.assert_called_once_with(
+            "foo", output_type=PersonOutput
+        )


### PR DESCRIPTION
> …instead of just querying for the name.

**Change Description:** 

The existing behavior simply searches for a user's display name, knowing that we're most likely to find the right result.
However, this has several problems that result in inaccurate output and inefficient queries.

This results in about a .4 second speed-up in clicking the 'More' button, and 6 fewer queries to PWS.
This also prevents people who are not the clicked-on person from showing up in the results.

Adds test to verify behavior.

This did spawn EDS-609, to improve the maintainability of the search_directory function, but it's not a critical task and was out of scope here.

**Closes Jira(s)**: EDS-566

## UW-Directory Pull Request checklist

- [x] I have run `./scripts/pre-push.sh`
- [x] I have selected a `semver-guidance:` label for this pull request (under labels,
      to the right of the screen)
