### PR TITLE
Fix several issues with the create-release workflow.

### DIFF
--- a/.github/steps/create-release/is-release-required.sh
+++ b/.github/steps/create-release/is-release-required.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -ex
-source .build-scripts/sources/github-actions.sh
+source ./.build-scripts/sources/github-actions.sh
 
 current_version=$(poetry version -s)
 latest_release=$(curl -s https://api.github.com/repos/UWIT-IAM/uw-husky-directory/releases | jq '.[0].tag_name')

--- a/.github/steps/create-release/push-release-image.sh
+++ b/.github/steps/create-release/push-release-image.sh
@@ -1,3 +1,4 @@
+set -e
 
 if [[ "${GITHUB_REF}" == "refs/heads/main" ]]
 then
@@ -11,7 +12,7 @@ docker tag $pr_image $release_image
 if [[ "${GITHUB_REF}" == 'refs/heads/main' ]]
 then
   docker push $release_image
-  ./scripts/update-dependency-image.sh --push
+  ./scripts/update-dependency-image.sh --push --strict
 else
   echo "Not pushing $release_image in dry-run mode."
 fi

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -28,7 +28,7 @@ jobs:
     if: needs.configure-release.outputs.release-required == 'true'
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.get-release.outputs.version }}
+      version: ${{ needs.configure-release.outputs.version }}
     strategy:
       max-parallel: 1
     steps:
@@ -62,16 +62,16 @@ jobs:
       - name: Tag and push release image
         env:
           pr_image: gcr.io/${{ secrets.IAM_GCR_REPO }}/husky-directory:pull-request-${{ steps.pr.outputs.number }}
-          release_image: gcr.io/${{ secrets.IAM_GCR_REPO }}/husky-directory:${{ steps.get-release.outputs.version }}
+          release_image: gcr.io/${{ secrets.IAM_GCR_REPO }}/husky-directory:${{ needs.configure-release.outputs.version }}
           # When using the dry-run branch, there is no PR to draw from, so we hard-code
           # a known-good image.
           testing_image: gcr.io/${{ secrets.IAM_GCR_REPO }}/husky-directory:1.0.1
         run: ${STEP_SCRIPTS}/push-release-image.sh
 
-      - name: Create release ${{ steps.get-release.outputs.version }}
+      - name: Create release ${{ needs.configure-release.outputs.version }}
         uses: ncipollo/release-action@v1
         with:
           # Use PAT so that the release will trigger the deployment workflow.
           token: ${{ secrets.ACTIONS_PAT }}
-          tag: ${{ steps.get-release.outputs.version }}
+          tag: ${{ needs.configure-release.outputs.version }}
         if: github.ref == 'refs/heads/main'

--- a/scripts/update-dependency-image.sh
+++ b/scripts/update-dependency-image.sh
@@ -7,6 +7,8 @@ function print_help {
    Options:
    -p, --push      Push the fingerprint after building, this is risk-free
                    and saves a lot of time in the future!
+   --head          Include the head (i.e., 'latest') tag on the image
+   --strict        Die on any errors
    -h, --help      Show this message and exit
    -g, --debug     Show commands as they are executing
 EOF
@@ -27,6 +29,15 @@ do
     --push|-p)
       PUSH=1
       ;;
+    --head)
+      TAG_LATEST=1
+      ;;
+    --debug|-g)
+      set -x
+      ;;
+    --strict)
+      set -e
+      ;;
     *)
       echo "Invalid Option: $1"
       print_help
@@ -43,7 +54,10 @@ fingerprint=$(./scripts/get-snapshot-fingerprint.sh)
   -i $image_repo:$fingerprint \
   -d docker/husky-directory-base.dockerfile
 
+test -z "${TAG_LATEST}" || docker tag $image_repo:$fingerprint $image_repo:latest
+
 if [[ -n "$PUSH" ]]
 then
   docker push $image_repo:$fingerprint
+  test -z "${TAG_LATEST}" || docker push $image_repo:latest
 fi


### PR DESCRIPTION
**Change Description:** 

- Fixes release job using wrong variable for new image version
- Ensures that an error in the configuration job will fail the build
- Ensures that when releasing, we update the `:latest` tag for our dependency image.

[Dry run succeeded](https://github.com/UWIT-IAM/uw-husky-directory/runs/3677801477?check_suite_focus=true)

## UW-Directory Pull Request checklist

- [x] I have run `./scripts/pre-push.sh`
- [x] I have selected a `semver-guidance:` label for this pull request (under labels,
      to the right of the screen)
