### PR TITLE
Use a simpler approach to create and push release images.

### DIFF
--- a/.github/steps/create-release/is-release-required.sh
+++ b/.github/steps/create-release/is-release-required.sh
@@ -8,7 +8,7 @@ latest_release=$(echo "${latest_release}" | sed 's|"||g')
 
 set_ci_output version "${current_version}"
 set_ci_output latest-release "${latest_release}"
-if [[ "${current_version}" == "${latest_release}" ]]
+if [[ "${current_version}" == "${latest_release}" && "${GITHUB_REF}" == "refs/heads/main" ]]
 then
   set_ci_output release-required false
 else

--- a/.github/steps/create-release/push-release-image.sh
+++ b/.github/steps/create-release/push-release-image.sh
@@ -1,18 +1,58 @@
-set -e
+function print_help {
+   cat <<EOF
+   Use: push-release-image.sh --version <semver> [--debug --help]
+   Options:
+   -v, --version   (Required)
+                   The release version you want to dockerize and push to gcr.
 
-if [[ "${GITHUB_REF}" == "refs/heads/main" ]]
-then
-  docker pull $pr_image
-else
-  docker pull $testing_image
-  docker tag $testing_image $pr_image
-fi
-docker tag $pr_image $release_image
+   --strict        Die on any errors
+   -h, --help      Show this message and exit
+   -g, --debug     Show commands as they are executing
+EOF
+}
 
-if [[ "${GITHUB_REF}" == 'refs/heads/main' ]]
+while (( $# ))
+do
+  case $1 in
+    --version|-v)
+      shift
+      release_version="$1"
+      ;;
+    --help|-h)
+      print_help
+      exit 0
+      ;;
+    --debug|-g)
+      DEBUG=1
+      set -x
+      ;;
+    --strict)
+      set -e
+      ;;
+    *)
+      echo "Invalid Option: $1"
+      print_help
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+test -n "${release_version}" || exit 1
+test "${GITHUB_REF}" == "refs/heads/main" || DRY_RUN=1
+
+./scripts/update-dependency-image.sh --strict --head \
+  $(test -n "${DRY_RUN}" || echo '--push') \
+  $(test -z "${DEBUG}" || echo "--debug" )
+
+./scripts/pre-push.sh \
+  --version $release_version \
+  --headless --skip-auto-format \
+  $(test -z "${DEBUG}" || echo "--debug")
+
+if [[ -z "${DRY_RUN}" ]]
 then
-  docker push $release_image
-  ./scripts/update-dependency-image.sh --push --strict
+  docker push gcr.io/uwit-mci-iam/husky-directory:$version
 else
   echo "Not pushing $release_image in dry-run mode."
 fi

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -53,21 +53,6 @@ jobs:
       - run: ./scripts/pre-push.sh --headless
         name: Validate build
 
-      - name: Actions Ecosystem Action Get Merged Pull Request
-        uses: actions-ecosystem/action-get-merged-pull-request@v1.0.1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-        id: pr
-
-      - name: Tag and push release image
-        env:
-          pr_image: gcr.io/${{ secrets.IAM_GCR_REPO }}/husky-directory:pull-request-${{ steps.pr.outputs.number }}
-          release_image: gcr.io/${{ secrets.IAM_GCR_REPO }}/husky-directory:${{ needs.configure-release.outputs.version }}
-          # When using the dry-run branch, there is no PR to draw from, so we hard-code
-          # a known-good image.
-          testing_image: gcr.io/${{ secrets.IAM_GCR_REPO }}/husky-directory:1.0.1
-        run: ${STEP_SCRIPTS}/push-release-image.sh
-
       - name: Create release ${{ needs.configure-release.outputs.version }}
         uses: ncipollo/release-action@v1
         with:
@@ -75,3 +60,26 @@ jobs:
           token: ${{ secrets.ACTIONS_PAT }}
           tag: ${{ needs.configure-release.outputs.version }}
         if: github.ref == 'refs/heads/main'
+
+  push-release-image:
+    needs: [configure-release, create-release]
+    runs-on: ubuntu-latest
+    env:
+      version: ${{ needs.configure-release.outputs.version }}
+    steps:
+      - run: |
+          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]
+          then
+            echo ::set-output name=release-ref::$version
+          else
+            echo ::set-output name=release-ref::${GITHUB_REF}
+          fi
+        name: Set the ref to check out from github
+        id: release-ref
+
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.release-ref.outputs.release-ref }}
+
+      - run: |
+          ${STEP_SCRIPTS}/push-release-image.sh -v ${{ env.version }} --strict

--- a/scripts/get-snapshot-fingerprint.sh
+++ b/scripts/get-snapshot-fingerprint.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Generates the sha256 fingerprint of the current
 # dependency image based on the declared lock files.
+./scripts/install-build-scripts.sh >/dev/null
 source ./.build-scripts/sources/fingerprints.sh
 
 image_name='husky-directory-base'

--- a/scripts/update-dependency-image.sh
+++ b/scripts/update-dependency-image.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
+./scripts/install-build-scripts.sh >/dev/null
 
 function print_help {
    cat <<EOF
-   Use: update-dependency-image.sh [--debug --help]
+   Use: update-dependency-image.sh [OPTIONS]
+
    Options:
    -p, --push      Push the fingerprint after building, this is risk-free
                    and saves a lot of time in the future!


### PR DESCRIPTION
**Change Description:** 
(Simpler, but more lines of code, because it's easier to understand and better documented.)

Lately a lot of work has gone into the deploy process, but the release process represented in automation
hasn't really caught up. As a result, some old ideals were being used which were causing
release images to be built without the properly set variables.

This update simplifies the workflow by separating the "github release" from the "docker push".
Doing so, we no longer have to try and resolve a pull-request as part of this workflow,
and instead check out the release tag when creating the docker image.

This saves us from accidentally introducing drift in what is released vs. what is running,
and unifies the process using the already ubiquitous `pre-push.sh`.

## UW-Directory Pull Request checklist

- [x] I have run `./scripts/pre-push.sh`
- [x] I have selected a `semver-guidance:` label for this pull request (under labels,
      to the right of the screen)
