### PR TITLE
Another small fix/tweak for the release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -81,5 +81,18 @@ jobs:
         with:
           ref: ${{ steps.release-ref.outputs.release-ref }}
 
+      - uses: google-github-actions/setup-gcloud@v0.2.1
+        with:
+          project_id: ${{ secrets.IAM_GCR_REPO }}
+          service_account_key: ${{ secrets.GCR_TOKEN }}
+          export_default_credentials: true
+          credentials_file_path: /tmp/gcloud.json
+        name: Bootstrap gcloud
+
+      - run: gcloud auth configure-docker gcr.io
+
       - run: |
           ${STEP_SCRIPTS}/push-release-image.sh -v ${{ env.version }} --strict
+      - run: |
+          ./scripts/deploy.sh -v ${{ env.version }} -t dev
+        if: github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,6 @@ on:
   push:
     branches:
       - dry-run-deploy
-  release:
-    types:
-      - released
   workflow_dispatch:
     inputs:
       cluster:
@@ -42,13 +39,6 @@ jobs:
           service_account_key: ${{ secrets.GCR_TOKEN }}
           export_default_credentials: true
         name: Bootstrap gcloud
-      # When pushing from a merge to main, we'll always deploy the latest
-      # created release to dev.
-      - if: github.event_name == 'release'
-        run: |
-          source ./.build-scripts/sources/github-actions.sh
-          set_env target_version "$(basename $GITHUB_REF)"
-        name: Configure new release deployment
 
       # When performing an automated dry run from a push, we will be running using
       # the basic default command of: ./deploy-sh --dry-run --target-cluster dev


### PR DESCRIPTION
**Change Description:** 

A race condition previously allowed the 'deploy' step to run before the image was actually pushed to GCR. I Remedied that by moving the deploy step into the create-release workflow.

Also, added gcr login step to the job that pushes to docker, which I forgot before but couldn't test because of dry runs.

## UW-Directory Pull Request checklist

- [x] I have run `./scripts/pre-push.sh`
- [x] I have selected a `semver-guidance:` label for this pull request (under labels,
      to the right of the screen)
