### PR TITLE
[EDS-611] Fix bug that shows employees even when only students are searched

### DIFF
--- a/husky_directory/services/search.py
+++ b/husky_directory/services/search.py
@@ -105,7 +105,8 @@ class DirectorySearchService:
                     student_affiliation_state=(
                         AffiliationState.current if population == "students" else None
                     ),
-                )
+                ),
+                populations=request_input.requested_populations,
             )
 
             statistics.aggregate(pws_output.request_statistics)
@@ -163,7 +164,7 @@ class DirectorySearchService:
             )
             statistics.num_queries_generated += 1
             pws_output: ListPersonsOutput = self._pws.list_persons(
-                generated.request_input
+                generated.request_input, populations=request_input.requested_populations
             )
             aggregate_output = pws_output
             statistics.aggregate(pws_output.request_statistics)

--- a/tests/blueprints/test_search_blueprint.py
+++ b/tests/blueprints/test_search_blueprint.py
@@ -67,7 +67,7 @@ class TestSearchBlueprint(BlueprintSearchTestBase):
             assert self.session.get("uwnetid")
 
         response = self.flask_client.post(
-            "/", data={"query": "lovelace", "length": "full"}
+            "/", data={"query": "lovelace", "length": "full", "population": "all"}
         )
 
         profile = self.mock_people.contactable_person

--- a/tests/services/test_search.py
+++ b/tests/services/test_search.py
@@ -58,7 +58,9 @@ class TestDirectorySearchService:
         self.mock_get_explicit_href.return_value = output
 
     def test_search_directory_happy(self):
-        request_input = SearchDirectoryInput(name="foo")
+        request_input = SearchDirectoryInput(
+            name="foo", population=PopulationType.employees
+        )
         output = self.client.search_directory(request_input)
 
         assert output.num_results
@@ -72,7 +74,9 @@ class TestDirectorySearchService:
         orig["Next"] = {"Href": "foo"}
         self.set_list_persons_output(orig)
         self.set_get_next_output(ListPersonsOutput.parse_obj(dupe))
-        request_input = SearchDirectoryInput(name="ada", search_type=search_type)
+        request_input = SearchDirectoryInput(
+            name="ada", search_type=search_type, population=PopulationType.all
+        )
         output = self.client.search_directory(request_input)
 
         # But we should only expect a single result because it was de-duplicated
@@ -82,7 +86,7 @@ class TestDirectorySearchService:
         person = self.mock_people.contactable_person
         self.list_persons_output["Persons"] = [person.dict(by_alias=True)]
         self.session["uwnetid"] = "foo"
-        request_input = SearchDirectoryInput(name="foo")
+        request_input = SearchDirectoryInput(name="foo", population=PopulationType.all)
         output = self.client.search_directory(request_input)
         contacts = output.scenarios[0].populations["employees"].people[0].phone_contacts
 


### PR DESCRIPTION
**Change Description:** Passes the `requested_populations` from the directory service to the PWS service, so that PWS can filter results based on the total populations requested, not just the authenticated allotments.

**Closes Jira(s)**: EDS-611

## UW-Directory Pull Request checklist

- [x] I have run `./scripts/pre-push.sh`
- [x] I have selected a `semver-guidance:` label for this pull request (under labels,
      to the right of the screen)
