### PR TITLE
[EDSI-615] Fix 'Phone: None' appearing in full listings of student searches

### DIFF
--- a/husky_directory/services/translator.py
+++ b/husky_directory/services/translator.py
@@ -35,7 +35,8 @@ class ListPersonsOutputTranslator:
             model = PhoneContactMethods()
 
         if student_affiliation:
-            model.phones.append(student_affiliation.directory_listing.phone)
+            if student_affiliation.directory_listing.phone:
+                model.phones.append(student_affiliation.directory_listing.phone)
 
         return model
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-husky-directory"
-version = "2.1.0"
+version = "2.1.1"
 description = "An updated version of the UW Directory"
 authors = ["Thomas Thorogood <goodtom@uw.edu>"]
 license = "MIT"

--- a/tests/blueprints/test_search_blueprint.py
+++ b/tests/blueprints/test_search_blueprint.py
@@ -119,6 +119,27 @@ class TestSearchBlueprint(BlueprintSearchTestBase):
                     "li", str(profile.affiliations.employee.mail_stop)
                 )
 
+    def test_render_student_no_phone(self):
+        self.flask_client.get("/saml/login", follow_redirects=True)
+        profile = self.mock_people.published_student
+        profile.affiliations.student.directory_listing.phone = None
+        profile.affiliations.employee = None
+        self.mock_send_request.return_value = self.mock_people.as_search_output(profile)
+
+        response = self.flask_client.post(
+            "/",
+            data={
+                "query": "lovelace",
+                "method": "name",
+                "length": "full",
+                "population": "all",
+            },
+        )
+
+        with self.html_validator.validate_response(response):
+            assert response.status_code == 200
+            self.html_validator.assert_not_has_tag_with_text("li", "Phone:")
+
     def test_render_no_results(self):
         self.mock_send_request.return_value = self.mock_people.as_search_output()
         response = self.flask_client.post("/", data={"query": "lovelace"})


### PR DESCRIPTION
**Closes Jira(s)**: EDS-615

## UW-Directory Pull Request checklist

- [x] I have run `./scripts/pre-push.sh`
- [x] I have selected a `semver-guidance:` label for this pull request (under labels, to the right of the screen)
