### PR TITLE
[EDS-616] Support "lastname, firstname" searches

### DIFF
--- a/husky_directory/models/search.py
+++ b/husky_directory/models/search.py
@@ -83,6 +83,10 @@ class SearchDirectoryFormInput(DirectoryBaseModel):
         if values.get("method") == "name":
             if len(v) < 2:
                 raise ValueError("Name query string must contain at least 2 characters")
+            # Allow users to input "last, first" for names.
+            if "," in v:
+                tokens = reversed(v.split(","))
+                v = " ".join(tokens).strip()
         elif len(v) < 3:
             raise ValueError("Query string must contain at least 3 characters")
         return v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-husky-directory"
-version = "2.1.1"
+version = "2.1.2"
 description = "An updated version of the UW Directory"
 authors = ["Thomas Thorogood <goodtom@uw.edu>"]
 license = "MIT"

--- a/tests/models/test_search_models.py
+++ b/tests/models/test_search_models.py
@@ -69,6 +69,19 @@ class TestSearchDirectoryFormInput:
         form_input = SearchDirectoryFormInput(render_population=render_population)
         assert PopulationType(form_input.render_population) == PopulationType(expected)
 
+    @pytest.mark.parametrize(
+        "name, expected",
+        [
+            ("lovelace, ada", "ada lovelace"),
+            ("ada lovelace", "ada lovelace"),
+            # Please note that "Ada" is already Ada Lovelace's middle name;
+            # she did not have a middle initial of "M" in real life.
+            ("lovelace, ada m", "ada m lovelace"),
+        ],
+    )
+    def test_sanitized_name(self, name, expected):
+        assert SearchDirectoryFormInput(method="name", query=name).query == expected
+
 
 @pytest.mark.parametrize(
     "query_value, expected_value",
@@ -79,9 +92,9 @@ class TestSearchDirectoryFormInput:
         # automatically stripped by pydantic
         ("\tfoo\t", "foo"),
         ("  foo bar  ", "foo bar"),
-        # Ensure tab characters are converted to spacees
+        # Ensure tab characters are converted to spaces
         ("foo\tbar", "foo bar"),
-        # Ensure multiple spaces are condensed to a single spacee
+        # Ensure multiple spaces are condensed to a single space
         ("foo     bar", "foo bar"),
         # Ensure all the things
         ("  foo\t   \t  bar    \t", "foo bar"),


### PR DESCRIPTION
**Change Description:** 

- Searches for `lastname, firstname` will work now. This is now an "undocumented feature" which is better than an "accidental regression," but I created EDS-617 for a future iteration to actually document this for users.

**Closes Jira(s)**: EDS-615, EDS-616

## UW-Directory Pull Request checklist

- [x] I have run `./scripts/pre-push.sh`
- [x] I have selected a `semver-guidance:` label for this pull request (under labels,
      to the right of the screen)
