### PR TITLE
[EDS-619] Re-support wildcard searches that were accidentally removed…

### DIFF
--- a/husky_directory/services/query_generator.py
+++ b/husky_directory/services/query_generator.py
@@ -157,6 +157,23 @@ class SearchQueryGenerator:
         )
 
     @staticmethod
+    def generate_name_queries(name):
+        """
+        We only execute this if a user has given  us a name
+        with a wildcard in it. Otherwise, the wildcard/reducer strategy is used.
+        """
+        if "*" in name:
+            yield GeneratedQuery(
+                description=f'Name matches "{name}"',
+                request_input=ListPersonsInput(display_name=name),
+            )
+        if not name.startswith("*"):
+            yield GeneratedQuery(
+                description=f'Name includes "{name}"',
+                request_input=ListPersonsInput(display_name=f"*{name}"),
+            )
+
+    @staticmethod
     def generate_email_queries(partial: str) -> Tuple[str, ListPersonsInput]:
         # If a user has supplied a full, valid email address, we will search only for the complete
         # listing as an 'is' operator.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-husky-directory"
-version = "2.1.2"
+version = "2.1.3"
 description = "An updated version of the UW Directory"
 authors = ["Thomas Thorogood <goodtom@uw.edu>"]
 license = "MIT"

--- a/tests/services/test_query_generator.py
+++ b/tests/services/test_query_generator.py
@@ -33,12 +33,20 @@ class TestSearchQueryGenerator:
             self.query_generator = injector.get(SearchQueryGenerator)
             yield
 
-    def test_wildcard_input(self):
+    def test_email_wildcard_input(self):
         generated = list(
             self.query_generator.generate(SearchDirectoryInput(email="foo*"))
         )
         assert len(generated) == 1
         assert generated[0].description == 'Email matches "foo*"'
+
+    def test_name_wildcard_input(self):
+        generated = list(
+            self.query_generator.generate(SearchDirectoryInput(name="foo*"))
+        )
+        assert len(generated) == 2
+        assert generated[0].description == 'Name matches "foo*"'
+        assert generated[1].description == 'Name includes "foo*"'
 
     def test_phone_input_short_number(self):
         request_input = SearchDirectoryInput(phone="2065554321")


### PR DESCRIPTION


**Change Description:** 2.0 accidentally removed support for wildcard searches in names. This fixes that.

**Closes Jira(s)**: EDS-619

## UW-Directory Pull Request checklist

- [x] I have run `./scripts/pre-push.sh`
- [x] I have selected a `semver-guidance:` label for this pull request (under labels,
      to the right of the screen)
