### PR TITLE
Update links.html

### DIFF
--- a/husky_directory/templates/links.html
+++ b/husky_directory/templates/links.html
@@ -18,12 +18,12 @@
                         <h4>Postal Addresses and Box Numbers at the UW</h4>
                         <ul>
                             <li>
-                              <a href="https://uw.edu/about/addressing-letters-to-the-uw/">
+                              <a href="https://www.washington.edu/about/addressing-letters-to-the-uw/">
                                   Addressing Letters to the UW</a> -
                               Find the postal address for a department.
                             </li>
                             <li>
-                              <a href="/home/boxnumbers/">UW Box Numbers</a> - Box numbers for UW departments.
+                              <a href="https://www.washington.edu/home/boxnumbers/">UW Box Numbers</a> - Box numbers for UW departments.
                             </li>
                         </ul>
                         <h4>Change your address or release information</h4>
@@ -31,16 +31,16 @@
                             <li><a href="https://identity.uw.edu"
                                 class="navlink">Faculty/staff publishing options</a>
                             </li>
-                            <li><a href="https://isc.uw.edu/"
+                            <li><a href="https://isc.uw.edu"
                                 class="navlink">Faculty/staff update contact information in Workday</a>
                             </li>
-                            <li><a href="//www.washington.edu/students/studentdirinfo.html"
+                            <li><a href="https://www.washington.edu/students/studentdirinfo.html"
                                 class="navlink">Student directory information</a>
                             </li>
-                            <li><a href="https://identity.uw.edu/"
+                            <li><a href="https://identity.uw.edu"
                                 class="navlink">Set a preferred name</a>
                             </li>
-                            <li><a href="//www.washington.edu/home/siteinfo/form/"
+                            <li><a href="https://www.washington.edu/home/siteinfo/form/"
                                 class="navlink">Update Office Information (help@uw.edu)</a>
                             </li>
                         </ul>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-husky-directory"
-version = "2.1.3"
+version = "2.1.4"
 description = "An updated version of the UW Directory"
 authors = ["Thomas Thorogood <goodtom@uw.edu>"]
 license = "MIT"


### PR DESCRIPTION
Customer reported https://directory.uw.edu/home/boxnumbers/ wasn't working.

**Change Description:** Fix several UW links at the bottom of directory tool

**Closes Jira(s)**: EDS-621

## UW-Directory Pull Request checklist

- [ ] I have run `./scripts/pre-push.sh`
- [ ] I have selected a `semver-guidance:` label for this pull request (under labels,
      to the right of the screen)
