### PR TITLE
[IAMTEAM-111] Fix users' display name casing being mangled during lexical analysis

### DIFF
--- a/husky_directory/models/pws.py
+++ b/husky_directory/models/pws.py
@@ -6,30 +6,13 @@ These are not 1:1 models of that API; only fields we care about are declared her
 """
 from __future__ import annotations
 
-import re
 from typing import Any, Dict, List, NoReturn, Optional
 
-from inflection import humanize
 from pydantic import BaseModel, Extra, Field, validator
 
-from .base import DirectoryBaseModel
 from .common import RecordConstraint, UWDepartmentRole
 from .enum import AffiliationState
 from ..util import camelize
-
-_can_humanize_expr = re.compile("^[a-zA-Z]+$")
-
-
-def humanize_(val: str) -> str:
-    """
-
-    Don't use the humanize function for names with punctuation,
-    as humanize may make them worse. For instance "Anne-marie"
-    instead of "Anne-Marie".
-    """
-    if re.fullmatch(_can_humanize_expr, val):
-        return humanize(val)
-    return val
 
 
 class PWSBaseModel(BaseModel):
@@ -157,7 +140,7 @@ class StudentDirectoryListing(PWSBaseModel):
     publish_in_directory: bool
     phone: Optional[str]
     email: Optional[str]
-    # "class" is a reserved keyword, so we have to name this field somethign else.
+    # "class" is a reserved keyword, so we have to name this field something else.
     class_level: Optional[str] = Field(default=None, alias="Class")
     departments: List[str] = []
 
@@ -188,144 +171,6 @@ class NamedIdentity(PWSBaseModel):
     preferred_first_name: Optional[str]
     preferred_middle_name: Optional[str]
     preferred_last_name: Optional[str] = Field(None, alias="PreferredSurname")
-
-    # These next fields are calculated on instantiation
-    # to make it easier to work with these names in
-    # meaningful ways. They are listed as optional
-    # because they aren't required to create the object,
-    # but they will always be populated during creation.
-    displayed_surname: Optional[str]
-    displayed_first_name: Optional[str]
-    displayed_middle_name: Optional[str]
-    name_tokens: List[str] = []
-    canonical_tokens: List[str] = []
-    sort_key: Optional[str]
-
-    @validator(
-        "display_name",
-        "registered_name",
-        "registered_first_middle_name",
-        "registered_surname",
-        "preferred_first_name",
-        "preferred_middle_name",
-        "preferred_last_name",
-        always=True,
-    )
-    def sanitize_name_fields(cls, value: Optional[str]) -> Optional[str]:
-        if value:
-            return " ".join(humanize_(v) for v in value.split())
-        return value
-
-    @validator("displayed_surname", always=True)
-    def populate_displayed_surname(cls, v: Any, values: Dict):
-        """
-        Returns the canonical surname for the identity, if there is one;
-        otherwise returns the last token in the user's display name.
-        """
-        display_name = values.get("display_name")
-        preferred_last_name = values.get("preferred_last_name")
-        registered_surname = values.get("registered_surname")
-
-        if preferred_last_name and preferred_last_name in display_name:
-            return preferred_last_name
-        elif registered_surname and registered_surname in display_name:
-            return registered_surname
-
-        # This should only happen if we have dirty data.
-        # If nothing makes sense, we'll just assume the
-        # default of a one-token surname.
-        return display_name.split()[-1]
-
-    @validator("displayed_first_name", always=True)
-    def populate_displayed_first_name(cls, v: Any, values: Dict):
-        """
-        Returns the canonical first name for the identity, if there is one;
-        otherwise returns the first token in the user's display name.
-        """
-        display_name = values.get("display_name")
-        last_name = values.get("displayed_surname")
-        last_name_index = display_name.index(last_name)
-        first_middle = display_name[:last_name_index]
-        preferred_first_name = values.get("preferred_first_name")
-        registered_first_middle = values.get("registered_first_middle_name")
-
-        if preferred_first_name and preferred_first_name in first_middle:
-            return preferred_first_name
-        elif registered_first_middle and registered_first_middle in first_middle:
-            return first_middle.strip()
-
-        # This should only happen if we have dirty data.
-        # If nothing makes sense, we'll just assume the
-        # default of a one-token name.
-        return display_name.split()[0]
-
-    @validator("displayed_middle_name", always=True)
-    def populate_displayed_middle_name(cls, v: Any, values: Dict):
-        """
-        Returns the canonical middle name for the identity, if
-        they have set a preferred middle name. Otherwise, returns
-        whatever part of the name is not the first name and is not the last name.
-        """
-        preferred_middle_name = values.get("preferred_middle_name")
-        registered_first_middle_name = values.get("registered_first_middle_name")
-        displayed_first_name = values.get("displayed_first_name")
-        displayed_surname = values.get("displayed_surname")
-        display_name = values.get("display_name")
-
-        if preferred_middle_name and preferred_middle_name in display_name:
-            return preferred_middle_name
-
-        splice_index = len(displayed_first_name) + 1
-
-        if (
-            registered_first_middle_name
-            and displayed_first_name in registered_first_middle_name
-        ):
-            middle_name = registered_first_middle_name[splice_index:]
-        else:
-            surname_index = display_name.index(displayed_surname)
-            middle_name = display_name[splice_index:surname_index]
-
-        if middle_name and middle_name in display_name:
-            return middle_name
-        return None
-
-    @validator("name_tokens", always=True)
-    def populate_name_tokens(cls, v: Any, values: Dict):
-        """
-        Populates a name tokens field to be used for processing,
-        grouping together tokens that are multi-token name pieces.
-        For instance "Ana Mari Cauce" will return ["Ana Mari", "Cauce"]
-        """
-        return [
-            values.get(field)
-            for field in (
-                "displayed_first_name",
-                "displayed_middle_name",
-                "displayed_surname",
-            )
-            if values.get(field)
-        ]
-
-    @validator("canonical_tokens", always=True)
-    def populate_sorted_name_tokens(cls, v: Any, values: Dict):
-        tokens = values.get("name_tokens")
-        result = [tokens[0]]
-        if len(tokens) > 1:
-            result.insert(0, tokens[-1])
-            if len(tokens) > 2:
-                result.extend(tokens[1:-1])
-        return result
-
-    @validator("sort_key", always=True)
-    def populate_sort_key(cls, v: Any, values: Dict):
-        """
-        Pre-calculates the sort key for the display name,
-        using the grouped name tokens.
-
-        "Ana Mari Cauce" becomes "Cauce Ana Mari"
-        """
-        return " ".join(values.get("canonical_tokens"))
 
 
 class PersonOutput(NamedIdentity):
@@ -380,28 +225,3 @@ class ListPersonsOutput(ListResponsesOutputWrapper):
     )
     previous: Optional[ListPersonsInput] = Field(None, description="See `next`")
     request_statistics: Optional[ListPersonsRequestStatistics]
-
-
-class ResultBucket(DirectoryBaseModel):
-    description: str
-    students: List[PersonOutput] = []
-    employees: List[PersonOutput] = []
-
-    # The relevance is an index value to help sort the
-    # buckets themselves. The lower the value, the closer
-    # to the beginning of a list of buckets this bucket will be.
-    relevance: int = 0
-
-    def add_person(self, pws_person: PersonOutput) -> NoReturn:
-        if pws_person.affiliations.employee:
-            self.employees.append(pws_person)
-        if pws_person.affiliations.student:
-            self.students.append(pws_person)
-
-    @property
-    def sorted_students(self) -> List[PersonOutput]:
-        return sorted(self.students, key=lambda p: p.sort_key)
-
-    @property
-    def sorted_employees(self) -> List[PersonOutput]:
-        return sorted(self.employees, key=lambda p: p.sort_key)

--- a/husky_directory/models/transforms.py
+++ b/husky_directory/models/transforms.py
@@ -1,0 +1,30 @@
+from typing import List, NoReturn
+
+from husky_directory.models.base import DirectoryBaseModel
+from husky_directory.models.pws import PersonOutput
+from husky_directory.services.name_analyzer import NameAnalyzer
+
+
+class ResultBucket(DirectoryBaseModel):
+    description: str
+    students: List[PersonOutput] = []
+    employees: List[PersonOutput] = []
+
+    # The relevance is an index value to help sort the
+    # buckets themselves. The lower the value, the closer
+    # to the beginning of a list of buckets this bucket will be.
+    relevance: int = 0
+
+    def add_person(self, pws_person: PersonOutput) -> NoReturn:
+        if pws_person.affiliations.employee:
+            self.employees.append(pws_person)
+        if pws_person.affiliations.student:
+            self.students.append(pws_person)
+
+    @property
+    def sorted_students(self) -> List[PersonOutput]:
+        return sorted(self.students, key=lambda p: NameAnalyzer(p).sort_key)
+
+    @property
+    def sorted_employees(self) -> List[PersonOutput]:
+        return sorted(self.employees, key=lambda p: NameAnalyzer(p).sort_key)

--- a/husky_directory/services/name_analyzer.py
+++ b/husky_directory/services/name_analyzer.py
@@ -1,0 +1,201 @@
+import re
+from typing import List, Optional
+
+from inflection import humanize
+
+from husky_directory.models.pws import NamedIdentity
+
+
+class NameAnalyzer:
+    _can_humanize_expr = re.compile("^[a-zA-Z]+$")
+
+    def __init__(self, identity: NamedIdentity):
+        self.identity = identity
+        self.__normalized: Optional[NamedIdentity] = None
+        self.__results = dict.fromkeys(
+            {
+                "displayed_surname",
+                "displayed_first_name",
+                "displayed_middle_name",
+                "name_tokens",
+                "canonical_tokens",
+                "sort_key",
+            },
+            None,
+        )
+
+    @property
+    def displayed_surname(self) -> str:
+        """
+        Some users have multiple tokens in their surname ("last name").
+        Rather than always assuming that the last word of the name is the surname,
+        we check the individual last_name/surname fields first so that we can
+        capture multiple-word names.
+        """
+        key = "displayed_surname"
+        if not self.__results[key]:
+            display_name = self.normalized.display_name
+            pref_last = self.normalized.preferred_last_name
+            reg_last = self.normalized.registered_surname
+            # If a user has set their preferred name, it will almost
+            # certainly be part of their displayed name, unless something
+            # is very wrong.
+            if pref_last and pref_last in display_name:
+                result = self.identity.preferred_last_name
+            # If a user has not set a preferred name, their
+            # registered surname will almost certainly be part of their
+            # display name, so we use that.
+            elif reg_last and reg_last in display_name:
+                result = self.identity.registered_surname
+            # But if neither the preferred nor the registered surname
+            # are part of the user's display name (which should not happen!)
+            # then we will assume the final "token" of the display name is
+            # their surname.
+            else:
+                result = self.identity.display_name.split()[-1]
+            self.__results[key] = result
+        return self.__results[key]
+
+    @property
+    def displayed_first_name(self) -> str:
+        """
+        Some users have multiple tokens in their given name ("first name").
+        Also, registered names combine first and  middle names, and therefore it is
+        not possible to tell what is a "first" name and what is a "middle" name
+        unless the user tells us by setting a preferred name.
+        """
+        key = "displayed_first_name"
+        if not self.__results[key]:
+            display_name = self.normalized.display_name
+            last_name = self.normalize_name_tokens(self.displayed_surname)
+            last_name_index = display_name.index(last_name)
+            first_middle = display_name[:last_name_index]
+            pref_first = self.normalized.preferred_first_name
+            reg_first_middle = self.normalized.registered_first_middle_name
+
+            # If the user has a preferred name set, and that name is in
+            # the display_name, return the preferred first name
+            if pref_first and pref_first in first_middle:
+                result = self.identity.preferred_first_name
+            # If the user has no preferred name set, but the registered name
+            # is part of the display name, return everything except for the last
+            # name from the display name.
+            elif reg_first_middle and reg_first_middle in first_middle:
+                result = self.identity.display_name[:last_name_index]
+            # If all else fails, and our data is dirty, make the assumption that the user
+            # has only a single-word first name, and that it's the first token of their
+            # display name. (Rather than using the registered first_middle name, which may
+            # include a middle name we don't want to assume is their first name.)
+            else:
+                result = self.identity.display_name.split()[0]
+            self.__results[key] = result
+        return self.__results[key]
+
+    @property
+    def displayed_middle_name(self) -> str:
+        key = "displayed_middle_name"
+        if self.__results[key] is None:  # The result may be an empty string
+            pref_middle = self.normalized.preferred_middle_name
+            display_name = self.normalized.display_name
+
+            if pref_middle and pref_middle in display_name:
+                result = self.identity.preferred_middle_name
+            else:
+                splice_index = len(self.displayed_first_name) + 1
+                surname_index = self.identity.display_name.index(self.displayed_surname)
+                result = self.identity.display_name[splice_index:surname_index]
+            if not result or result not in self.identity.display_name:
+                result = ""
+            self.__results[key] = result
+
+        return self.__results[key]
+
+    @property
+    def name_tokens(self) -> List[str]:
+        key = "name_tokens"
+        if not self.__results[key]:
+            result = list(
+                filter(
+                    lambda i: bool(i),
+                    [
+                        self.displayed_first_name,
+                        self.displayed_middle_name,
+                        self.displayed_surname,
+                    ],
+                )
+            )
+            self.__results[key] = result
+        return self.__results[key]
+
+    @property
+    def canonical_name_tokens(self) -> List[str]:
+        """
+        Reorders ["First", "Middle", "Last"] as ["Last", "First", "Middle"]
+        """
+        key = "canonical_tokens"
+        if not self.__results[key]:
+            result = self.name_tokens.copy()
+            sort_seed = result.pop(-1)
+            result.insert(0, sort_seed)
+            self.__results[key] = result
+        return self.__results[key]
+
+    @property
+    def sort_key(self) -> str:
+        """
+        "First Middle Last" becomes "last first middle" for lexical
+        sorting purposes.
+        """
+        key = "sort_key"
+        if not self.__results[key]:
+            result = " ".join([i.lower() for i in self.canonical_name_tokens])
+            self.__results[key] = result
+        return self.__results[key]
+
+    @classmethod
+    def humanize(cls, val: str) -> str:
+        """
+
+        Don't use the humanize function for names with punctuation,
+        as humanize may make them worse. For instance "Anne-marie"
+        instead of "Anne-Marie".
+        """
+        if re.fullmatch(cls._can_humanize_expr, val):
+            return humanize(val)
+        return val
+
+    @property
+    def normalized(self) -> NamedIdentity:
+        if not self.__normalized:
+            normalized_keys = {
+                "display_name",
+                "registered_name",
+                "registered surname",
+                "registered_first_middle_name",
+                "preferred_first_name",
+                "preferred_middle_name",
+                "preferred_last_name",
+            }
+            raw_values = self.identity.dict(include=normalized_keys)
+            normalized = NamedIdentity.parse_obj(
+                {k: self.normalize_name_tokens(v) for k, v in raw_values.items()}
+            )
+            self.__normalized = normalized
+        return self.__normalized
+
+    @classmethod
+    def normalize_name_tokens(cls, value: str) -> str:
+        """
+        Because the data we receive from PWS may contain
+        names with different casing, we have to normalize them.
+        We split on spaces and humanize each so that each is
+        capitalized; humanizing the entire string at once
+        leads to some not-very namely results.
+
+        Note: The display_name should only be normalized
+        for comparative purposes, and never be preserved;
+        we should always display the display name as is!
+        """
+        if value:
+            return " ".join(cls.humanize(v) for v in value.split())
+        return value

--- a/husky_directory/services/translator.py
+++ b/husky_directory/services/translator.py
@@ -8,7 +8,6 @@ from husky_directory.models.pws import (
     EmployeePersonAffiliation,
     ListPersonsOutput,
     PersonOutput,
-    ResultBucket,
     StudentPersonAffiliation,
 )
 from husky_directory.models.search import (
@@ -16,6 +15,7 @@ from husky_directory.models.search import (
     Person,
     PhoneContactMethods,
 )
+from husky_directory.models.transforms import ResultBucket
 
 
 @singleton

--- a/husky_directory/services/vcard.py
+++ b/husky_directory/services/vcard.py
@@ -8,6 +8,7 @@ from injector import inject
 
 from husky_directory.models.pws import PersonOutput
 from husky_directory.models.vcard import VCard, VCardAddress, VCardPhone, VCardPhoneType
+from husky_directory.services.name_analyzer import NameAnalyzer
 from husky_directory.services.pws import PersonWebServiceClient
 
 
@@ -102,7 +103,7 @@ class VCardService:
     def get_vcard(self, href: str) -> BytesIO:
         person = self.pws.get_explicit_href(href, output_type=PersonOutput)
 
-        last_name, *other_names = person.canonical_tokens
+        last_name, *other_names = NameAnalyzer(person).canonical_name_tokens
         vcard = VCard.construct(
             last_name=last_name,
             name_extras=other_names,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-husky-directory"
-version = "2.1.4"
+version = "2.1.5"
 description = "An updated version of the UW Directory"
 authors = ["Thomas Thorogood <goodtom@uw.edu>"]
 license = "MIT"

--- a/tests/models/test_pws_models.py
+++ b/tests/models/test_pws_models.py
@@ -1,7 +1,8 @@
 from husky_directory.models.pws import NamedIdentity, PersonOutput
+from husky_directory.services.name_analyzer import NameAnalyzer
 
 
-def test_name_formatting():
+def test_name_analyzer():
     identity = NamedIdentity(
         display_name="ALOE VERA",
         registered_name="aloe VERA",
@@ -11,24 +12,16 @@ def test_name_formatting():
         preferred_middle_name="A.",
         preferred_last_name="VERA",
     )
+    analyzer = NameAnalyzer(identity)
 
-    expected = {
-        "display_name": "Aloe Vera",
-        "registered_name": "Aloe Vera",
-        "registered_first_middle_name": "Aloe A. Vera",
-        "registered_surname": "Vera",
-        "preferred_first_name": "Aloe",
-        "preferred_middle_name": "A.",
-        "preferred_last_name": "Vera",
-        "displayed_first_name": "Aloe",
-        "displayed_middle_name": None,
-        "displayed_surname": "Vera",
-        "sort_key": "Vera Aloe",
-        "canonical_tokens": ["Vera", "Aloe"],
-        "name_tokens": ["Aloe", "Vera"],
-    }
-
-    assert identity.dict() == expected
+    assert analyzer.normalized.display_name == "Aloe Vera"
+    assert analyzer.identity.display_name == "ALOE VERA"
+    assert analyzer.name_tokens == ["Aloe", "VERA"]
+    assert analyzer.canonical_name_tokens == ["VERA", "Aloe"]
+    assert analyzer.displayed_first_name == "Aloe"
+    assert analyzer.displayed_surname == "VERA"
+    assert analyzer.displayed_middle_name == ""
+    assert analyzer.sort_key == "vera aloe"
 
 
 def test_person_output_href():

--- a/tests/services/test_reducer.py
+++ b/tests/services/test_reducer.py
@@ -3,7 +3,7 @@ import pytest
 from husky_directory.models.pws import ListPersonsOutput, NamedIdentity
 from husky_directory.services.reducer import (
     NameSearchResultReducer,
-    NamedIdentityAnalyzer,
+    NameQueryResultAnalyzer,
 )
 
 
@@ -25,7 +25,9 @@ class TestNamedIdentityAnalyzer:
         ],
     )
     def test_relevant_bucket(self, query, bucket):
-        assert NamedIdentityAnalyzer(self.identity, query).relevant_bucket[0] == bucket
+        assert (
+            NameQueryResultAnalyzer(self.identity, query).relevant_bucket[0] == bucket
+        )
 
 
 class TestNameSearchResultReducer:


### PR DESCRIPTION
**Change Description:** Moves name analysis out of the model and into a separate class that can be invoked as needed. This prevents the actual display name from ever being manipulated, which has the intended side effect of displaying the user's actual display name, instead of something uncannily similar, but not quite their name.

**Closes Jira(s)**: [IAMTEAM-111](https://jira.cac.washington.edu/browse/IAMTEAM-111)

## UW-Directory Pull Request checklist

- [x] I have run `./scripts/pre-push.sh`
- [x] I have selected a `semver-guidance:` label for this pull request (under labels,
      to the right of the screen)
