### PR TITLE
[EDS-14] Use a preferences cookie to retain the last set response detail

### DIFF
--- a/husky_directory/app_config.py
+++ b/husky_directory/app_config.py
@@ -119,6 +119,7 @@ class SessionSettings(FlaskConfigurationSettings):
     cookie_name: str = Field(
         "edu.uw.directory.session", env="SESSION_COOKIE_NAME", flask_config_key="_env"
     )
+    preferences_cookie_name: str = Field("edu.uw.directory.preferences")
     secret_key: SecretStr = Field(None, env="SECRET_KEY", flask_config_key="_env")
     lifetime_seconds: int = Field(
         600, env="PERMANENT_SESSION_LIFETIME", flask_config_key="_env"

--- a/husky_directory/models/common.py
+++ b/husky_directory/models/common.py
@@ -12,6 +12,8 @@ from typing import Any, Callable, Dict, Optional, Union
 
 from pydantic import BaseModel, validator
 
+from husky_directory.models.enum import ResultDetail
+
 
 class UWDepartmentRole(BaseModel):
     """Denotes that an identity has some role within the UW (e.g., a job title, or class level)."""
@@ -129,3 +131,14 @@ class RecordConstraint(BaseModel):
         if not isinstance(v, RecordNamespace):
             return RecordNamespace.validate(v)
         return v
+
+
+class PreferencesCookie(BaseModel):
+    class Config:
+        use_enum_values = True
+
+    result_detail: ResultDetail = ResultDetail.summary
+
+    @property
+    def result_detail_enum(self) -> ResultDetail:
+        return ResultDetail(self.result_detail)

--- a/husky_directory/templates/search.html
+++ b/husky_directory/templates/search.html
@@ -11,7 +11,7 @@
                 <input type="text" class="form-control"
                        value="{{ search_value }}"
                        style="color:black; height:43px; z-index:0;" id="query"
-                       {{ 'autofocus' if request_input is blank }}
+                       {{ 'autofocus' if search_value is blank }}
                        name="query">
                 <span class="input-group-btn">
                     <button class="btn search"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-husky-directory"
-version = "2.1.5"
+version = "2.1.6"
 description = "An updated version of the UW Directory"
 authors = ["Thomas Thorogood <goodtom@uw.edu>"]
 license = "MIT"


### PR DESCRIPTION
**Change Description:** Now, if a user last selected "full" details of a search, their next visit will default to "full", and vice-versa (although "vice-versa" is the default behavior).

**Closes Jira(s)**: EDS-14

## UW-Directory Pull Request checklist

- [x] I have run `./scripts/pre-push.sh`
- [x] I have selected a `semver-guidance:` label for this pull request (under labels,
      to the right of the screen)
