### PR TITLE
[GH-155] update version retrieval for deploy to eval (a promotion from dev to eval)

### DIFF
--- a/scripts/get-deployed-version.sh
+++ b/scripts/get-deployed-version.sh
@@ -53,7 +53,7 @@ function parse_args {
 function get_stage_version {
   local stage=$1
   local url=$(get_stage_url $stage)
-  local version=$(curl -Ssl ${url}/status | grep version | cut -f2 -d: | sed 's| ||g')
+  local version=$(curl -Ssl ${url}/status | jq .version | sed 's|"||g')
   # version will return something similar to 2.2.5, no "v" prefix.
   echo "${version}"
 }


### PR DESCRIPTION
**Change Description:** 
Change the `target_version` from `'"<version>"'` to `<version>` - allows deployment notification to succeed, unblocking the rest of the deployment

It worked here https://github.com/UWIT-IAM/uw-husky-directory/actions/runs/3832480478/jobs/6522833559#step:5:43

**Closes GH Issues(s)**: 
GH-155


## UW-Directory Pull Request checklist

- [x] I have run `poetry run tox`
- [x] I have selected a `semver-guidance:` label for this pull request (under labels,
      to the right of the screen)
