### PR TITLE
[GH-163] replace the deprecated 'set-output' with GITHUB_OUTPUT

### DIFF
--- a/.github/steps/create-release/is-release-required.sh
+++ b/.github/steps/create-release/is-release-required.sh
@@ -5,11 +5,11 @@ current_version=$(get_poetry_version)
 latest_release=$(curl -s https://api.github.com/repos/UWIT-IAM/uw-husky-directory/releases | jq '.[0].tag_name')
 latest_release=$(echo "${latest_release}" | sed 's|"||g')
 
-echo "::set-output name=version::${current_version}"
-echo "::set-output name=latest-release::${latest_release}"
+echo "version=${current_version}" >> $GITHUB_OUTPUT
+echo "latest-release=${latest_release}" >> $GITHUB_OUTPUT
 if [[ "${current_version}" == "${latest_release}" && "${GITHUB_REF}" == "refs/heads/main" ]]
 then
-  echo "::set-output name=release-required::false"
+  echo "release-required=false" >> $GITHUB_OUTPUT
 else
-  echo "::set-output name=release-required::true"
+  echo "release-required=true" >> $GITHUB_OUTPUT
 fi

--- a/.github/steps/deploy/configure-canvas.sh
+++ b/.github/steps/deploy/configure-canvas.sh
@@ -7,7 +7,7 @@ canvas=$(${STEP_SCRIPTS}/get_slack_notification.sh \
   -q "${deployment_qualifier}" \
   -c "#iam-bot-sandbox")  # TODO
 
-echo "::set-output name=slack-canvas::$(echo $canvas)"
+echo "slack-canvas=$(echo $canvas)" >> $GITHUB_OUTPUT
 echo "Slack canvas json: $canvas"
 
 context_artifact=$(${STEP_SCRIPTS}/get_slack_notification.sh \
@@ -16,7 +16,7 @@ context_artifact=$(${STEP_SCRIPTS}/get_slack_notification.sh \
   -s "$target_cluster" \
   -q "${deployment_qualifier}")
 
-echo "::set-output name=context-artifact::$(echo $context_artifact)"
+echo "context-artifact=$(echo $context_artifact)" >> $GITHUB_OUTPUT
 echo "Context artifact: $context_artifact"
 
 set -e

--- a/.github/steps/pull-request/create-pr-tag.sh
+++ b/.github/steps/pull-request/create-pr-tag.sh
@@ -42,5 +42,5 @@ tag_name="pull-request-${pr_number}"
 dest_image="${DOCKER_REPOSITORY}.app:${tag_name}"
 docker tag "${source_image}" ${dest_image}
 docker push "${dest_image}"
-echo "::set-output name=image::${dest_image}"
+echo "image=${dest_image}" >> $GITHUB_OUTPUT
 echo "::notice::Pushed image https://${dest_image}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -83,7 +83,7 @@ jobs:
           else
             target_version=$(./scripts/get-deployed-version.sh -s ${source_stage})
           fi
-          echo "::set-output name=target-version::${target_version}"
+          echo "target-version=${target_version}" >> $GITHUB_OUTPUT
       # For shared instances (dev, eval, prod) we create a slack notification
       # so that others can be aware of the change.
       # TODO: Eval and prod deployment notifications should go to #iam-uwnetid
@@ -117,7 +117,7 @@ jobs:
         id: audit
         run: |
           slack_link="<${{ env.rfc }} | Audit Record>"
-          echo "::set-output name=context::[${slack_link}]"
+          echo "context=[${slack_link}]" >> $GITHUB_OUTPUT
 
       # If we have a Slack notification for this change, add a context artifact to it.
       # This provides at-a-glance links and details in the slack notification for

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -120,8 +120,8 @@ function configure_deployment {
   fi
   if [[ -n "${GITHUB_REF}" ]]
   then
-    echo "::set-output name=target-cluster::$target_cluster"
-    echo "::set-output name=target-version::$deploy_version"
+    echo "target-cluster=$target_cluster" >> $GITHUB_OUTPUT
+    echo "target-version=$deploy_version" >> $GITHUB_OUTPUT
   fi
 }
 


### PR DESCRIPTION
**Change Description:** 
See above. Right now, we only get warnings, but soon they will generate failures.

**Closes GH(s)**:
GH-163

There are scripts in the actions repo that also affect this flow, those will be addressed separately.

More info here
https://github.com/UWIT-IAM/uw-idp-web-tests/issues/29. https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## UW-Directory Pull Request checklist

- [x] I have run `poetry run tox`
- [x] I have selected a `semver-guidance:` label for this pull request (under labels,
      to the right of the screen)
