### PR TITLE
[GH-165] - Prevent double Base64 encoding of profile href + Github Actions updates

### DIFF
--- a/.github/actions/configure-docker/action.yml
+++ b/.github/actions/configure-docker/action.yml
@@ -12,10 +12,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: google-github-actions/auth@v0
+    - uses: google-github-actions/auth@v2
       with:
         credentials_json: ${{ inputs.gcr-token }}
-    - uses: google-github-actions/setup-gcloud@v1.0.1
+    - uses: google-github-actions/setup-gcloud@v2.1.0
 
       # archiving leaving this "with" section, might b a handy reference at a later date.
       # It was there when the above "uses" was uses: google-github-actions/setup-gcloud@v0

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -49,7 +49,12 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
-      - uses: abatilo/actions-poetry@v2.1.6
+      # Install Poetry using pipx
+      - name: Install Poetry with pipx
+        run: |
+          pipx install poetry
+          poetry --version  # Verify that Poetry was installed correctly
+
       - run: |
           sudo apt-get -y install jq
           poetry run pip install tox uw-it-build-fingerprinter

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -49,19 +49,18 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-
       - name: Install Poetry with pipx
         run: |
           pipx install poetry
           poetry --version  # Verify that Poetry was installed correctly
 
+      - name: Configure Poetry environment with Python 3.10
+        run: |
+          poetry env use python3.10
+
       - run: |
           sudo apt-get -y install jq
-          poetry run pip install tox uw-it-build-fingerprinter
+          poetry run pip install tox uw-it-build-fingerprinter  # Install required Python dependencies
         id: configure
         name: Set up environment
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,16 +21,16 @@ jobs:
       new-version: ${{ steps.update-version.outputs.new-version }}
     steps:
       - name: Python Poetry Action
-        uses: abatilo/actions-poetry@v2.1.6
+        run: pipx install poetry
 
       - uses: uwit-iam/actions/require-semver-guidance-label@0.1
         id: guidance
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
 
-      - uses: uwit-iam/actions/update-pr-branch-version@0.1.16
+      - uses: uwit-iam/actions/update-pr-branch-version@0.1.20
         with:
-          github-token: ${{ env.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           version-guidance: ${{ steps.guidance.outputs.guidance }}
         id: update-version
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -49,7 +49,11 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
-      # Install Poetry using pipx
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
       - name: Install Poetry with pipx
         run: |
           pipx install poetry

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -49,18 +49,20 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
-      - name: Install Poetry with pipx
-        run: |
-          pipx install poetry
-          poetry --version  # Verify that Poetry was installed correctly
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
 
-      - name: Configure Poetry environment with Python 3.10
+      - name: Install Poetry with pip
         run: |
-          poetry env use python3.10
+          python -m pip install --upgrade pip
+          python -m pip install poetry
+          poetry --version
 
       - run: |
           sudo apt-get -y install jq
-          poetry run pip install tox uw-it-build-fingerprinter  # Install required Python dependencies
+          poetry run pip install tox uw-it-build-fingerprinter
         id: configure
         name: Set up environment
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: uwit-iam/actions/update-pr-branch-version@0.1.20
         with:
-          github-token: ${{ env.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           version-guidance: ${{ steps.guidance.outputs.guidance }}
         id: update-version
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -26,11 +26,11 @@ jobs:
       - uses: uwit-iam/actions/require-semver-guidance-label@0.1
         id: guidance
         with:
-          github-token: ${{ github.token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: uwit-iam/actions/update-pr-branch-version@0.1.20
         with:
-          github-token: ${{ github.token }}
+          github-token: ${{ env.GITHUB_TOKEN }}
           version-guidance: ${{ steps.guidance.outputs.guidance }}
         id: update-version
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-husky-directory"
-version = "2.2.7"
+version = "2.2.8"
 description = "An updated version of the UW Directory"
 authors = ["Thomas Thorogood <goodtom@uw.edu>"]
 license = "MIT"


### PR DESCRIPTION
**Change Description:**  This PR fixes a bug in the `b64_encode_href` method of the Person model that caused double Base64 encoding of the `href` when navigating back in the browser. Changes I've made:

1. **Updated `b64_encode_href` validator**:
   - The method now checks if the `href` is already Base64 encoded before encoding it again, preventing the double encoding issue.

<img width="1472" alt="Screenshot 2025-01-15 at 10 04 14 PM" src="https://github.com/user-attachments/assets/f5e90205-d970-4e0d-ae2c-822432b02fa8" />


2. **Github Actions**:
   - Automated tests were failing due to outdated dependencies.
   - Switched to using pipx for installing Poetry and updated the Google dependencies.

<img width="1142" alt="Screenshot 2025-01-15 at 10 52 37 PM" src="https://github.com/user-attachments/assets/9749c95f-a492-401a-83f9-04a0c4d87024" />

**Closes Github(s)**: [GH-165](https://github.com/UWIT-IAM/uw-husky-directory/issues/165)

## UW-Directory Pull Request checklist

- [X] I have run `poetry run tox`
- [X] I have selected a `semver-guidance:` label for this pull request (under labels,
      to the right of the screen)
