### PR TITLE
[GH-167] - Update PWS_HOST with new value from REQ7051889

### DIFF
--- a/husky_directory/models/enum.py
+++ b/husky_directory/models/enum.py
@@ -7,7 +7,7 @@ from enum import Enum
 class AffiliationState(Enum):
     """
     These are defined by PWS but only enumerated in their test UI:
-    https://it-wseval1.s.uw.edu/identity/v2/person
+    https://wseval.s.uw.edu/identity/v2/person
     """
 
     current = "current"

--- a/husky_directory/models/pws.py
+++ b/husky_directory/models/pws.py
@@ -1,6 +1,6 @@
 """
 Models for PWS inputs and outputs. These act as declarative, typed abstractions over
-the PWS API definitions at https://it-wseval1.s.uw.edu/identity/swagger/index.html#/
+the PWS API definitions at https://wseval.s.uw.edu/identity/swagger/index.html#/
 
 These are not 1:1 models of that API; only fields we care about are declared here.
 """

--- a/husky_directory/services/pws.py
+++ b/husky_directory/services/pws.py
@@ -231,7 +231,7 @@ class PersonWebServiceClient(AppLoggerMixIn):
         """
         Given an input request, queries PWS and returns the output.
         For more information on this request,
-        see https://it-wseval1.s.uw.edu/identity/swagger/index.html#/PersonV2/PersonSearch
+        see https://wseval.s.uw.edu/identity/swagger/index.html#/PersonV2/PersonSearch
         """
         payload = request_input.payload
         constraints = self.global_constraints + request_input.constraints

--- a/husky_directory/settings/base.dotenv
+++ b/husky_directory/settings/base.dotenv
@@ -1,7 +1,7 @@
 FLASK_ENV=development
 UWCA_CERT_NAME=uwca
 UWCA_CERT_PATH=/app/certificates
-PWS_HOST=https://it-wseval1.s.uw.edu
+PWS_HOST=https://wseval.s.uw.edu
 PWS_DEFAULT_PATH=/identity/v2
 HOST=directory.iamdev.s.uw.edu
 SAML_ENTITY_ID=https://${HOST}/saml

--- a/husky_directory/settings/compose-with-redis.dotenv
+++ b/husky_directory/settings/compose-with-redis.dotenv
@@ -1,6 +1,6 @@
 UWCA_CERT_NAME=uwca
 UWCA_CERT_PATH=/app/certificates
-PWS_HOST=https://it-wseval1.s.uw.edu
+PWS_HOST=https://wseval.s.uw.edu
 PWS_DEFAULT_PATH=/identity/v2
 HOST=uw-directory.iamdev.s.uw.edu
 SAML_ENTITY_ID=https://${HOST}/saml


### PR DESCRIPTION
**Context**: During a recent live session, we encountered an issue with the `PWS_HOST` configuration while running locally. The following was observed:

1. Using `PWS_HOST=https://it-wseval1.s.uw.edu` consistently resulted in `500` errors.
2. Switching to `PWS_HOST=https://wseval.s.uw.edu` resolved the issue, and the application worked as expected.

After doing some research I found a change that took effect in EWS EVAL environments on 5/25/23. Any configurations or bookmarks still pointing to the old endpoint will no longer work.

**Change Description:** 
This PR updates the `PWS_HOST` value in the `settings/*.dotenv` files to reflect the current configuration for the EWS EVAL environments. The old endpoint `https://it-wseval1.s.uw.edu` consistently caused 500 errors during local testing. The new endpoint `https://wseval.s.uw.edu` resolves this issue and aligns with changes implemented on 5/25/23.

For more information please refer to UW Connect's REQ7051889

**Closes Github(s)**:  [GH-167](https://github.com/UWIT-IAM/uw-husky-directory/issues/167)

## UW-Directory Pull Request checklist

- [X] I have run `poetry run tox` (Please check Side Note)
- [X] I have selected a `semver-guidance:` label for this pull request (under labels,
      to the right of the screen)
