### PR TITLE
[GH-169] Fix create-release.yml Workflow Issues and Update Poetry Tox Command Syntax

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
       - dry-run-create-release
+      - GH-169
+  workflow_dispatch:
 
 env:
   STEP_SCRIPTS: ${{ github.workspace }}/.github/steps/create-release
@@ -40,21 +42,33 @@ jobs:
       - uses: UWIT-IAM/actions/configure-gcloud-docker-gcloud-v101@0.1.17
         with:
           gcloud-token: ${{ secrets.GCR_TOKEN }}
-      - name: Install poetry
-        uses: abatilo/actions-poetry@v2.1.6
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install Poetry with pip
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install poetry
+          poetry --version
+
+
       - run: |
           sudo apt-get -y install jq
-          poetry run pip install uw-it-build-fingerprinter tox
-      - run: |
+          poetry run pip install tox uw-it-build-fingerprinter
+
+      - name: Validate Build and Test
+        run: |
           poetry run tox -e build-layers \
-            -- -t ${{ env.version }} --release ${{ env.version }} --cache \
+            -- -- -t ${{ env.version }} --release ${{ env.version }} --cache \
             --build-arg HUSKY_DIRECTORY_VERSION=${{ env.version }}
           poetry run tox -e unit-tests
         # Build layers with the -k option to avoid installing a lot of
         # unnecessary dependencies. We can also skip black/flake8 for
         # this phase, because the code has already been accepted into
         # the repository.
-        name: Validate build
 
       - name: Create release ${{ needs.configure-release.outputs.version }}
         uses: ncipollo/release-action@v1
@@ -62,9 +76,11 @@ jobs:
           tag: ${{ needs.configure-release.outputs.version }}
         if: github.ref == 'refs/heads/main'
 
-      - run: docker push gcr.io/uwit-mci-iam/husky-directory:${{ env.version }}
+      - name: Push Docker image
+        run: docker push gcr.io/uwit-mci-iam/husky-directory:${{ env.version }}
         if: github.ref == 'refs/heads/main'
 
-      - run: |
+      - name: Deploy
+        run: |
           ./scripts/deploy.sh -t dev -v ${{ env.version }} \
             ${{ github.ref != 'refs/heads/main' && '-x' || '' }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - dry-run-create-release
-      - GH-169
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
**Change Description:** This PR fixes issues with the `create-release.yml` workflow by making the following updates:  

1. **Installations and Setup:**  
   -  Setting up Python 3.10 using `actions/setup-python@v4`.
   -  Installing Poetry manually with `pip`

2. **Command Fixes:**  
   - Adjusted the `tox` command to include `--` for passing additional arguments correctly, addressing a Poetry behavior where `--` is eaten if not explicitly included.  Reference: [Stack Overflow link for Poetry and Tox argument handling](https://stackoverflow.com/questions/75056352/poetry-tox-how-to-pass-arguments-to-commands-via-tox-when-running-in-poetry).

3. **Other Minor Adjustments:**  
   - Added names to a few steps for better clarity.
   - Added `workflow_dispatch` to allow manual triggering of the workflow.

**Testing**:
To test this workflow before merging, I temporarily added the branch name `GH-169` so that the workflow was triggered, and everything is now green.

<img width="496" alt="Screenshot 2025-01-16 at 5 09 19 PM" src="https://github.com/user-attachments/assets/406767ae-4021-4956-b7b7-94e076eb1103" />

<img width="1314" alt="Screenshot 2025-01-16 at 5 09 02 PM" src="https://github.com/user-attachments/assets/6be1b40f-5e3b-4462-ab92-92119112e65a" />



**Closes Gihutb(s)**: [GH-169](https://github.com/UWIT-IAM/uw-husky-directory/issues/169)

## UW-Directory Pull Request checklist

- [X] I have run `poetry run tox`
- [X] I have selected a `semver-guidance:` label for this pull request (under labels,
      to the right of the screen)
