### PR TITLE
[GH-174] - Allow all "whitepages email addresses" to appear for users on all screens

### DIFF
--- a/husky_directory/models/search.py
+++ b/husky_directory/models/search.py
@@ -1,6 +1,7 @@
 """
 Models for the DirectorySearchService.
 """
+
 from __future__ import annotations
 
 import base64
@@ -210,7 +211,7 @@ class PhoneContactMethods(DirectoryBaseModel):
 class Person(DirectoryBaseModel):
     name: str
     phone_contacts: PhoneContactMethods = PhoneContactMethods()
-    email: Optional[str]
+    emails: List[str] = []
     box_number: Optional[str]
     departments: List[UWDepartmentRole] = []
     sort_key: Optional[str]

--- a/husky_directory/models/search.py
+++ b/husky_directory/models/search.py
@@ -1,7 +1,6 @@
 """
 Models for the DirectorySearchService.
 """
-
 from __future__ import annotations
 
 import base64

--- a/husky_directory/models/vcard.py
+++ b/husky_directory/models/vcard.py
@@ -107,6 +107,6 @@ class VCard(DirectoryBaseModel):
     display_name: str
     titles: List[str] = []
     departments: List[str] = []
-    email: Optional[str]
+    emails: List[str] = []
     phones: List[VCardPhone] = []
     addresses: List[str] = []

--- a/husky_directory/services/translator.py
+++ b/husky_directory/services/translator.py
@@ -45,7 +45,11 @@ class ListPersonsOutputTranslator:
         student: StudentPersonAffiliation,
         result_in_progress: Person,
     ) -> NoReturn:
-        result_in_progress.email = student.directory_listing.email
+        # Supports multiple emails: students have one, employees may have many.
+        # Assigning student email as a single-item list for consistency.
+        if student.directory_listing.email:
+            result_in_progress.emails = [student.directory_listing.email]
+
         result_in_progress.departments.extend(
             UWDepartmentRole(
                 title=student.directory_listing.class_level, department=dept
@@ -58,11 +62,10 @@ class ListPersonsOutputTranslator:
     def _translate_employee_attributes(
         employee: EmployeePersonAffiliation, result_in_progress: Person
     ) -> NoReturn:
-        # Email will usually be the same, but just in case, we'll prefer the
-        # employee email address and not overwrite it with the student's if
-        # it's already set.
+        # Display all available employee emails
+        # More info on: https://github.com/UWIT-IAM/uw-husky-directory/issues/174
         if employee.directory_listing.emails:
-            result_in_progress.email = employee.directory_listing.emails[0]
+            result_in_progress.emails = employee.directory_listing.emails
 
         result_in_progress.box_number = employee.mail_stop
         result_in_progress.departments.extend(

--- a/husky_directory/services/translator.py
+++ b/husky_directory/services/translator.py
@@ -49,7 +49,6 @@ class ListPersonsOutputTranslator:
         # Assigning student email as a single-item list for consistency.
         if student.directory_listing.email:
             result_in_progress.emails = [student.directory_listing.email]
-
         result_in_progress.departments.extend(
             UWDepartmentRole(
                 title=student.directory_listing.class_level, department=dept

--- a/husky_directory/services/vcard.py
+++ b/husky_directory/services/vcard.py
@@ -71,7 +71,7 @@ class VCardService:
         # If student email exists, we prefer employee email (in case they are different),
         # so we overwrite.
         if employee.emails:
-            vcard.email = employee.emails[0]
+            vcard.emails = employee.emails
 
         if employee.addresses:
             vcard.addresses = [
@@ -95,7 +95,7 @@ class VCardService:
                 VCardPhone(types=[VCardPhoneType.home], value=student.phone)
             )
         if student.email:
-            vcard.email = student.email
+            vcard.emails.append(student.email)
 
         if student.class_level:
             vcard.titles.append(student.class_level)

--- a/husky_directory/templates/full_result.html
+++ b/husky_directory/templates/full_result.html
@@ -1,6 +1,8 @@
 <h4>{{ person['name'] }}</h4>
 <ul class="dir-listing">
-    <li>{{ person['email'] }}</li>
+    {% for email in person['emails'] %}
+        <li>{{ email }}</li>
+    {% endfor %}
     {% for contact_method, numbers in
                            person['phone_contacts'].items() %}
         {% if numbers|length %}

--- a/husky_directory/templates/summary_results_table/scenario_population_block.html
+++ b/husky_directory/templates/summary_results_table/scenario_population_block.html
@@ -23,7 +23,12 @@ and then 1 or more rows of results. #}
             {% set phone = data['phone_contacts']['phones']|first %}
             {% if phone %}{{ phone }}{% endif %}
         </td>
-        <td valign="top">{{ data['email'] }}&nbsp;</td>
+        <td valign="top">
+            {% for email in data['emails'] %}
+                {{ email }}{% if not loop.last %}, {% endif %}
+            {% endfor %}
+            &nbsp;
+        </td>
         <td>
             {% set form_id = "more-form-" ~ loop.index  %}
             <form action="/person/listing" id="{{ form_id }}"

--- a/husky_directory/templates/vcard.vcf.jinja2
+++ b/husky_directory/templates/vcard.vcf.jinja2
@@ -15,9 +15,9 @@ FN:{{ display_name }}
     ORG:University of Washington;{{ dept }}
 {% endfor %}
 {# EMAIL;type=INTERNET,type=WORK:dawg@uw.edu #}
-{% if not email is blank -%}
+{% for email in emails -%}
     EMAIL;type=INTERNET,type=WORK:{{ email }}
-{% endif %}
+{% endfor %}
 {# TEL;type="pager,voice":5558675309 #}
 {% for phone in phones -%}
     TEL;type="{% for pt in phone['types'] -%}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-husky-directory"
-version = "2.2.9"
+version = "2.3.0"
 description = "An updated version of the UW Directory"
 authors = ["Thomas Thorogood <goodtom@uw.edu>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-husky-directory"
-version = "2.2.8"
+version = "2.2.9"
 description = "An updated version of the UW Directory"
 authors = ["Thomas Thorogood <goodtom@uw.edu>"]
 license = "MIT"

--- a/tests/services/test_translator.py
+++ b/tests/services/test_translator.py
@@ -41,8 +41,10 @@ class TestPersonOutputTranslator:
 
         person = employees.people[0]
 
-        # Ensure student email was overwritten by employee email
-        assert person.email == "dawg@uw.edu"
+        # Ensure student email is overwritten by employee email,
+        # and verify that both employee emails are displayed instead of just one.
+        # More on: https://github.com/UWIT-IAM/uw-husky-directory/blob/main/tests/conftest.py#L135
+        assert person.emails == ["dawg@uw.edu", "dawg2@uw.edu"]
         assert person.box_number == "351234"
         assert person.phone_contacts.phones == ["2068675309 Ext. 4242", "19999674222"]
         assert person.departments[0].department == "Cybertronic Engineering"

--- a/tests/services/test_vcard.py
+++ b/tests/services/test_vcard.py
@@ -87,7 +87,7 @@ class TestVCardServiceAttributeResolution:
             VCardPhone(types=["MSG"], value="5555555"),
         ]
 
-        assert vcard.email == "employee@uw.edu"
+        assert vcard.emails == ["employee@uw.edu"]
         assert vcard.departments == ["Snack Eating", "Napping"]
         assert vcard.titles == ["Chief of Kibble Testing", "Assistant Snuggler"]
 
@@ -95,7 +95,7 @@ class TestVCardServiceAttributeResolution:
         vcard = VCard.construct()
         self.service.set_student_vcard_attrs(vcard, student)
         assert vcard.phones == [VCardPhone(types=["home"], value="4444444")]
-        assert vcard.email == "student@uw.edu"
+        assert vcard.emails == ["student@uw.edu"]
         assert vcard.titles == ["Goodboi"]
         assert vcard.departments == ["Barkochemical Engineering"]
 


### PR DESCRIPTION
**Change Description:** This PR addresses the discussion in the Service team meeting on 1/27/2025 regarding email display. The following changes have been made:
- **For employees**: Previously, only the first email (index 0) in the array of emails was shown. Now, all available employee emails are displayed.
- **For students**: Remains the same, only the single directory listing email is displayed, as students have only one email.
- **Email preference**: Remains the same. If both student and employee emails exist, employee emails are prioritized over student emails and takes precedence.
- **vCard support for multiple emails**: The vCard now supports multiple email addresses for employees, displaying all available emails rather than just one.

For more details, refer to the GitHub issue below.

**Closes Github(s)**: [GH-174](https://github.com/UWIT-IAM/uw-husky-directory/issues/174)
**UW Connect Request**: REQ10541593

**Note**: The following changes have been deployed to our dev instance: https://directory.iamdev.s.uw.edu/. For more details about the affected NetID and screenshots, please refer to REQ10541593
## UW-Directory Pull Request checklist

- [X] I have run `poetry run tox`
- [X] I have selected a `semver-guidance:` label for this pull request (under labels,
      to the right of the screen)
