### PR TITLE
[GH-188] - Add mobile phone number to summary search result

### DIFF
--- a/husky_directory/templates/summary_results_table/scenario_population_block.html
+++ b/husky_directory/templates/summary_results_table/scenario_population_block.html
@@ -20,7 +20,13 @@ and then 1 or more rows of results. #}
         <td valign="top">{{ data['name'] }}&nbsp;</td>
         <td valign="top" nowrap="nowrap">
             {% set phone = data['phone_contacts']['phones']|first %}
-            {% if phone %}{{ phone }}{% endif %}
+            {% set mobile = data['phone_contacts']['mobiles']|first %}
+
+            {% if phone %}
+                {{ phone }}
+            {% elif mobile %}
+                {{ mobile }}
+            {% endif %}
         </td>
         <td valign="top">
             {% for email in data['emails'] %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-husky-directory"
-version = "2.4.1"
+version = "2.4.2"
 description = "An updated version of the UW Directory"
 authors = ["Thomas Thorogood <goodtom@uw.edu>"]
 license = "MIT"


### PR DESCRIPTION
**Change Description:** If a person doesn't have an office/landline number in `data['phone_contacts']['phones']`, we should display their first mobile number from `data['phone_contacts']['mobiles']` instead. The goal for the summary view is to show a contact number when available, with preference given to landline numbers when present. Users can view all other available phone numbers by clicking 'more' on the summary view or switching to full view mode.

**Closes Github Issue(s)**: [GH-188](https://github.com/UWIT-IAM/uw-husky-directory/issues/188)

**UW Connect Request**: REQ11008424

**Testing Checklist**:
- [x] Test with contacts having only landline numbers (`pass`, `jprosser`)
- [x] Test with contacts having only mobile numbers (`ariccaid`, `minnivan`)
- [x] Test with contacts having both types of numbers (`solonika` , `kd79coop`)
- [x] Test with contacts having no numbers (`althoff`, `brettwo`, `chk`)

**Note**: This PR is deployed to our `dev` instance.

## UW-Directory Pull Request checklist

- [X] A corresponding Github Issue has been created in [this repository](https://github.com/UWIT-IAM/uw-husky-directory/issues) to track this work
- [X] I have run `poetry run tox`
- [X] I have selected a `semver-guidance:` label for this pull request (under labels,
      to the right of the screen)

If you do not do both of these things, your checks will either not run, or have a high probability of failing.
