### PR TITLE
[GH-223] update urllib3 to 2.7.0 to close security vulnerabilities

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2050,14 +2050,14 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
-    {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-husky-directory"
-version = "2.4.8"
+version = "2.4.9"
 description = "An updated version of the UW Directory"
 authors = ["Thomas Thorogood <goodtom@uw.edu>"]
 license = "MIT"


### PR DESCRIPTION
**Change Description:** poetry update urllib3 (to 2.7.0)

**Closes Github Issue(s)**: GH-223

## UW-Directory Pull Request checklist

- [x] A corresponding Github Issue has been created in [this repository](https://github.com/UWIT-IAM/uw-husky-directory/issues) to track this work
- [x] I have run `poetry run tox`
- [x] I have selected a `semver-guidance:` label for this pull request (under labels,
      to the right of the screen)
- 
If you do not do both of these things, your checks will either not run, or have a high probability of failing.
